### PR TITLE
"ADB over network" GUI option in LineageOS

### DIFF
--- a/docs/guide/adb-over-tcp.md
+++ b/docs/guide/adb-over-tcp.md
@@ -36,4 +36,8 @@ adb kill-server
 ADB over TCP will be disabled after a restart. In that case, you have to run the stated command again to enable it.
 :::
 
+::: tip
+LineageOS contains a GUI option for enabling "ADB over network" in the developer options.
+:::
+
 [1]: https://www.xda-developers.com/install-adb-windows-macos-linux/


### PR DESCRIPTION
To avoid confusion, I think it is good to acknowledge in the docs that LineageOS contains a graphical option for enabling ADB over IP.