### PR TITLE
Show install apk button in ScannerActivity

### DIFF
--- a/app/src/main/java/io/github/muntashirakon/AppManager/scanner/ScannerActivity.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/scanner/ScannerActivity.java
@@ -34,6 +34,7 @@ import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.util.Pair;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
@@ -64,6 +65,7 @@ import androidx.core.content.ContextCompat;
 import io.github.muntashirakon.AppManager.BaseActivity;
 import io.github.muntashirakon.AppManager.R;
 import io.github.muntashirakon.AppManager.StaticDataset;
+import io.github.muntashirakon.AppManager.apk.installer.PackageInstallerActivity;
 import io.github.muntashirakon.AppManager.types.EmptySpan;
 import io.github.muntashirakon.AppManager.types.NumericSpan;
 import io.github.muntashirakon.AppManager.types.ScrollableDialogBuilder;
@@ -91,6 +93,7 @@ public class ScannerActivity extends BaseActivity {
     private String mPackageName;
     private ParcelFileDescriptor fd;
     private File apkFile;
+    private Uri apkUri;
 
     @Override
     protected void onDestroy() {
@@ -128,7 +131,7 @@ public class ScannerActivity extends BaseActivity {
         mProgressIndicator.setVisibilityAfterHide(View.GONE);
         showProgress(true);
 
-        final Uri apkUri = intent.getData();
+        apkUri = intent.getData();
         if (apkUri == null) {
             Toast.makeText(this, getString(R.string.error), Toast.LENGTH_LONG).show();
             finish();
@@ -252,10 +255,21 @@ public class ScannerActivity extends BaseActivity {
     }
 
     @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.activity_scanner, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         int id = item.getItemId();
         if (id == android.R.id.home) {
             finish();
+            return true;
+        } else if (id == R.id.action_install_apk) {
+            Intent openApk = new Intent(getBaseContext(), PackageInstallerActivity.class);
+            openApk.setData(apkUri);
+            startActivity(openApk);
             return true;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/res/menu/activity_scanner.xml
+++ b/app/src/main/res/menu/activity_scanner.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_install_apk"
+        android:icon="@drawable/ic_baseline_get_app_24"
+        app:iconTint="?android:attr/colorAccent"
+        android:title="@string/install_apk"
+        app:showAsAction="ifRoom"/>
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -794,4 +794,5 @@
     <string name="share">Share</string>
     <string name="resend_intent">Resend Intent</string>
     <string name="interceptor">Interceptor</string>
+    <string name="install_apk">Install APK</string>
 </resources>


### PR DESCRIPTION
I mainly use the `ScannerActivity` to scan newly downloaded apk files and then decide whether to install them or not.
When I want to install them I currently have to reopen the apk file in the package installer, that is why I also cannot set the Scanner to "use always".
This pull request adds a small button the menu action bar, which sends the apk uri to the `PackageInstallerActivity`, through which it could be installed.
This has two benefits: First, I do not have to reopen the file and second, I can set the the `ScannerActivity` to the activity that always handles apk file intents.
![screen1](https://user-images.githubusercontent.com/36813904/102538054-13763a80-40ac-11eb-9f13-fbda23c75f0a.png)

I also tested it with a small button at the end, but I think the first one fits better:
![screen2](https://user-images.githubusercontent.com/36813904/102538897-32c19780-40ad-11eb-8aa3-8a4947674e4c.png)