### PR TITLE
ServerManager: Invert startServer() check

### DIFF
--- a/app/src/main/java/io/github/muntashirakon/AppManager/servermanager/LocalServerManager.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/servermanager/LocalServerManager.java
@@ -95,7 +95,7 @@ class LocalServerManager {
             } catch (Exception ignore) {
             }
             if (mSession == null) {
-                if (startServer()) {
+                if (!startServer()) {
                     throw new IOException("Failed to start server.");
                 }
                 mSession = createSession();


### PR DESCRIPTION
A successful server launch returns `true`. A "Failed to start server" exception was thrown on `true`. Throw on `false` instead now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/muntashirakon/appmanager/285)
<!-- Reviewable:end -->
