### PR TITLE
Add checklist to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,13 @@ assignees: ''
 
 ---
 
+<!--
+Your issue will be closed without warning if you don't check at least two items.
+-->
+- [ ] I know what my device, OS and App Manager versions are
+- [ ] I know how to take logs
+- [ ] I know how to reproduce the issue which may not be specific to my device
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,13 @@ assignees: ''
 
 ---
 
+<!--
+You must select two of the following items, otherwise your issue will be closed without notice:
+-->
+- [ ] I am using the latest version of App Manager
+- [ ] I have searched the issues and haven't found anything relevant
+- [ ] I have read the docs
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 


### PR DESCRIPTION
In order to prevent abuse and repeated asking for logs/device info, checklists are added to ensure that the user actually read the instructions and/or cared enough to do an actual contribution.