### PR TITLE
Store backup info in the database for faster loading

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,11 @@ android {
         targetSdkVersion rootProject.ext.targetSdk
         versionCode 388
         versionName "2.7.0"
+        javaCompileOptions {
+            annotationProcessorOptions {
+                arguments = ["room.schemaLocation": "$projectDir/schemas".toString()]
+            }
+        }
     }
 
     signingConfigs {
@@ -67,6 +72,9 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+    }
+    sourceSets {
+        androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
 }
 

--- a/app/schemas/io.github.muntashirakon.AppManager.db.AMDatabase/5.json
+++ b/app/schemas/io.github.muntashirakon.AppManager.db.AMDatabase/5.json
@@ -1,0 +1,337 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "2d67750e288d10d848e222bdbe1942a1",
+    "entities": [
+      {
+        "tableName": "app",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`package_name` TEXT NOT NULL, `user_id` INTEGER NOT NULL DEFAULT -10000, `label` TEXT, `version_name` TEXT, `version_code` INTEGER NOT NULL, `flags` INTEGER NOT NULL DEFAULT 0, `uid` INTEGER NOT NULL DEFAULT 0, `shared_uid` TEXT DEFAULT NULL, `first_install_time` INTEGER NOT NULL DEFAULT 0, `last_update_time` INTEGER NOT NULL DEFAULT 0, `target_sdk` INTEGER NOT NULL DEFAULT 0, `cert_name` TEXT DEFAULT '', `cert_algo` TEXT DEFAULT '', `is_installed` INTEGER NOT NULL DEFAULT true, `is_enabled` INTEGER NOT NULL DEFAULT false, `has_activities` INTEGER NOT NULL DEFAULT false, `has_splits` INTEGER NOT NULL DEFAULT false, `rules_count` INTEGER NOT NULL DEFAULT 0, `tracker_count` INTEGER NOT NULL DEFAULT 0, `last_action_time` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`package_name`, `user_id`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-10000"
+          },
+          {
+            "fieldPath": "packageLabel",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "version_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "versionCode",
+            "columnName": "version_code",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sharedUserId",
+            "columnName": "shared_uid",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "firstInstallTime",
+            "columnName": "first_install_time",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "last_update_time",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sdk",
+            "columnName": "target_sdk",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "certName",
+            "columnName": "cert_name",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "certAlgo",
+            "columnName": "cert_algo",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "isInstalled",
+            "columnName": "is_installed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "is_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "hasActivities",
+            "columnName": "has_activities",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "hasSplits",
+            "columnName": "has_splits",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "rulesCount",
+            "columnName": "rules_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "trackerCount",
+            "columnName": "tracker_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastActionTime",
+            "columnName": "last_action_time",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "package_name",
+            "user_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "log_filter",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "file_hash",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`path` TEXT NOT NULL, `hash` TEXT, PRIMARY KEY(`path`))",
+        "fields": [
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "path"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "backup",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`package_name` TEXT NOT NULL, `backup_name` TEXT NOT NULL, `label` TEXT, `version_name` TEXT, `version_code` INTEGER NOT NULL, `is_system` INTEGER NOT NULL, `has_splits` INTEGER NOT NULL, `has_rules` INTEGER NOT NULL, `backup_time` INTEGER NOT NULL, `crypto` TEXT, `meta_version` INTEGER NOT NULL, `flags` INTEGER NOT NULL, `user_id` INTEGER NOT NULL, `tar_type` TEXT, `has_key_store` INTEGER NOT NULL, `installer_app` TEXT, PRIMARY KEY(`backup_name`, `package_name`))",
+        "fields": [
+          {
+            "fieldPath": "packageName",
+            "columnName": "package_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backupName",
+            "columnName": "backup_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "versionName",
+            "columnName": "version_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "versionCode",
+            "columnName": "version_code",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSystem",
+            "columnName": "is_system",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasSplits",
+            "columnName": "has_splits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasRules",
+            "columnName": "has_rules",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backupTime",
+            "columnName": "backup_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "crypto",
+            "columnName": "crypto",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "meta_version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tarType",
+            "columnName": "tar_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hasKeyStore",
+            "columnName": "has_key_store",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installer",
+            "columnName": "installer_app",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "backup_name",
+            "package_name"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2d67750e288d10d848e222bdbe1942a1')"
+    ]
+  }
+}

--- a/app/src/main/java/io/github/muntashirakon/AppManager/AppManager.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/AppManager.java
@@ -52,7 +52,8 @@ public class AppManager extends Application {
     public static synchronized AMDatabase getDb() {
         if (db == null) {
             db = Room.databaseBuilder(getContext(), AMDatabase.class, "am")
-                    .addMigrations(AMDatabase.MIGRATION_1_2, AMDatabase.MIGRATION_2_3, AMDatabase.MIGRATION_3_4)
+                    .addMigrations(AMDatabase.MIGRATION_1_2, AMDatabase.MIGRATION_2_3, AMDatabase.MIGRATION_3_4,
+                            AMDatabase.MIGRATION_4_5)
                     .build();
         }
         return db;

--- a/app/src/main/java/io/github/muntashirakon/AppManager/backup/BackupUtils.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/backup/BackupUtils.java
@@ -15,28 +15,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
+import io.github.muntashirakon.AppManager.AppManager;
+import io.github.muntashirakon.AppManager.db.entity.Backup;
 import io.github.muntashirakon.AppManager.logcat.helper.SaveLogHelper;
 import io.github.muntashirakon.io.FileStatus;
 import io.github.muntashirakon.io.ProxyFile;
 import io.github.muntashirakon.io.ProxyFiles;
 
 public final class BackupUtils {
-    @WorkerThread
-    @Nullable
-    public static MetadataManager.Metadata getBackupInfo(String packageName) {
-        MetadataManager.Metadata[] metadata = MetadataManager.getMetadata(packageName);
-        if (metadata.length == 0) return null;
-        int maxIndex = 0;
-        long maxTime = 0;
-        for (int i = 0; i < metadata.length; ++i) {
-            if (metadata[i].backupTime > maxTime) {
-                maxIndex = i;
-                maxTime = metadata[i].backupTime;
-            }
-        }
-        return metadata[maxIndex];
-    }
-
     @NonNull
     private static List<String> getBackupPackages() {
         File backupPath = BackupFiles.getBackupDirectory();
@@ -54,19 +40,54 @@ public final class BackupUtils {
 
     @WorkerThread
     @NonNull
-    public static HashMap<String, MetadataManager.Metadata> getAllBackupMetadata() {
-        HashMap<String, MetadataManager.Metadata> backupMetadata = new HashMap<>();
-        List<String> backupPackages = getBackupPackages();
-        for (String dirtyPackageName : backupPackages) {
-            MetadataManager.Metadata metadata = getBackupInfo(dirtyPackageName);
-            if (metadata == null) continue;
-            MetadataManager.Metadata metadata1 = backupMetadata.get(metadata.packageName);
-            if (metadata1 == null) {
-                backupMetadata.put(metadata.packageName, metadata);
-            } else if (metadata.backupTime > metadata1.backupTime) {
-                backupMetadata.put(metadata.packageName, metadata);
-            } else {
-                backupMetadata.put(metadata1.packageName, metadata1);
+    public static HashMap<String, Backup> storeAllAndGetLatestBackupMetadata() {
+        HashMap<String, Backup> backupMetadata = new HashMap<>();
+        HashMap<String, List<MetadataManager.Metadata>> allBackupMetadata = getAllMetadata();
+        List<Backup> backups = new ArrayList<>();
+        for (List<MetadataManager.Metadata> metadataList : allBackupMetadata.values()) {
+            if (metadataList.size() == 0) continue;
+            Backup latestBackup = null;
+            Backup backup;
+            for (MetadataManager.Metadata metadata : metadataList) {
+                backup = Backup.fromBackupMetadata(metadata);
+                backups.add(backup);
+                if (latestBackup == null || backup.backupTime > latestBackup.backupTime) {
+                    latestBackup = backup;
+                }
+            }
+            backupMetadata.put(latestBackup.packageName, latestBackup);
+        }
+        AppManager.getDb().backupDao().insert(backups);
+        return backupMetadata;
+    }
+
+    @WorkerThread
+    @Nullable
+    public static Backup storeAllAndGetLatestBackupMetadata(String packageName) {
+        MetadataManager.Metadata[] allBackupMetadata = MetadataManager.getMetadata(packageName);
+        List<Backup> backups = new ArrayList<>();
+        Backup latestBackup = null;
+        Backup backup;
+        for (MetadataManager.Metadata metadata : allBackupMetadata) {
+            backup = Backup.fromBackupMetadata(metadata);
+            backups.add(backup);
+            if (latestBackup == null || backup.backupTime > latestBackup.backupTime) {
+                latestBackup = backup;
+            }
+        }
+        AppManager.getDb().backupDao().insert(backups);
+        return latestBackup;
+    }
+
+    @WorkerThread
+    @NonNull
+    public static HashMap<String, Backup> getAllLatestBackupMetadataFromDb() {
+        HashMap<String, Backup> backupMetadata = new HashMap<>();
+        List<Backup> backups = AppManager.getDb().backupDao().getAll();
+        for (Backup backup : backups) {
+            Backup latestBackup = backupMetadata.get(backup.packageName);
+            if (latestBackup == null || backup.backupTime > latestBackup.backupTime) {
+                backupMetadata.put(backup.packageName, backup);
             }
         }
         return backupMetadata;
@@ -83,7 +104,7 @@ public final class BackupUtils {
         for (String dirtyPackageName : backupPackages) {
             MetadataManager.Metadata[] metadataList = MetadataManager.getMetadata(dirtyPackageName);
             for (MetadataManager.Metadata metadata : metadataList) {
-                if (backupMetadata.get(metadata.packageName) == null) {
+                if (!backupMetadata.containsKey(metadata.packageName)) {
                     backupMetadata.put(metadata.packageName, new ArrayList<>());
                 }
                 //noinspection ConstantConditions

--- a/app/src/main/java/io/github/muntashirakon/AppManager/db/AMDatabase.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/db/AMDatabase.java
@@ -7,14 +7,17 @@ import androidx.room.Database;
 import androidx.room.RoomDatabase;
 import androidx.room.migration.Migration;
 import androidx.sqlite.db.SupportSQLiteDatabase;
+
 import io.github.muntashirakon.AppManager.db.dao.AppDao;
+import io.github.muntashirakon.AppManager.db.dao.BackupDao;
 import io.github.muntashirakon.AppManager.db.dao.FileHashDao;
 import io.github.muntashirakon.AppManager.db.dao.LogFilterDao;
 import io.github.muntashirakon.AppManager.db.entity.App;
+import io.github.muntashirakon.AppManager.db.entity.Backup;
 import io.github.muntashirakon.AppManager.db.entity.FileHash;
 import io.github.muntashirakon.AppManager.db.entity.LogFilter;
 
-@Database(entities = {App.class, LogFilter.class, FileHash.class}, version = 4)
+@Database(entities = {App.class, LogFilter.class, FileHash.class, Backup.class}, version = 5)
 public abstract class AMDatabase extends RoomDatabase {
     public static final Migration MIGRATION_1_2 = new Migration(1, 2) {
         @Override
@@ -38,7 +41,20 @@ public abstract class AMDatabase extends RoomDatabase {
         }
     };
 
+    public static final Migration MIGRATION_4_5 = new Migration(4, 5) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            database.execSQL("CREATE TABLE IF NOT EXISTS backup (package_name TEXT NOT NULL, " +
+                    "backup_name TEXT NOT NULL, label TEXT, version_name TEXT, version_code INTEGER, " +
+                    "is_system INTEGER, has_splits INTEGER, has_rules INTEGER, backup_time INTEGER, crypto TEXT, " +
+                    "meta_version INTEGER, flags INTEGER, user_id INTEGER, tar_type TEXT, has_key_store INTEGER, " +
+                    "installer_app TEXT, PRIMARY KEY (package_name, backup_name))");
+        }
+    };
+
     public abstract AppDao appDao();
+
+    public abstract BackupDao backupDao();
 
     public abstract LogFilterDao logFilterDao();
 

--- a/app/src/main/java/io/github/muntashirakon/AppManager/db/dao/BackupDao.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/db/dao/BackupDao.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package io.github.muntashirakon.AppManager.db.dao;
+
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Update;
+
+import java.util.List;
+
+import io.github.muntashirakon.AppManager.db.entity.Backup;
+
+@Dao
+public interface BackupDao {
+    @Query("SELECT * FROM backup")
+    List<Backup> getAll();
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insert(List<Backup> backups);
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insert(Backup backup);
+
+    @Update
+    void update(Backup backup);
+
+    @Delete
+    void delete(Backup backup);
+
+    @Delete
+    void delete(List<Backup> backups);
+
+    @Query("DELETE FROM backup WHERE package_name = :packageName AND backup_name = :backupName")
+    void delete(String packageName, String backupName);
+}

--- a/app/src/main/java/io/github/muntashirakon/AppManager/db/entity/App.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/db/entity/App.java
@@ -170,6 +170,34 @@ public class App implements Serializable {
         return app;
     }
 
+    @NonNull
+    public static App fromBackup(@NonNull Backup backup) {
+        App app = new App();
+        app.packageName = backup.packageName;
+        app.uid = 0;
+        app.userId = backup.userId;
+        app.isInstalled = false;
+        if (backup.isSystem) {
+            app.flags |= ApplicationInfo.FLAG_SYSTEM;
+        }
+        app.isEnabled = true;
+        app.packageLabel = backup.label;
+        app.sdk = 0;
+        app.versionName = backup.versionName;
+        app.versionCode = backup.versionCode;
+        app.sharedUserId = null;
+        app.certName = "";
+        app.certAlgo = "";
+        app.firstInstallTime = backup.backupTime;
+        app.lastUpdateTime = backup.backupTime;
+        app.hasActivities = false;
+        app.hasSplits = backup.hasSplits;
+        app.rulesCount = 0;
+        app.trackerCount = 0;
+        app.lastActionTime = backup.backupTime;
+        return app;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/app/src/main/java/io/github/muntashirakon/AppManager/db/entity/Backup.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/db/entity/Backup.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+package io.github.muntashirakon.AppManager.db.entity;
+
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+
+import org.json.JSONException;
+
+import java.io.File;
+
+import io.github.muntashirakon.AppManager.backup.BackupFiles;
+import io.github.muntashirakon.AppManager.backup.BackupFlags;
+import io.github.muntashirakon.AppManager.backup.CryptoUtils;
+import io.github.muntashirakon.AppManager.backup.MetadataManager;
+import io.github.muntashirakon.AppManager.utils.TarUtils;
+import io.github.muntashirakon.io.ProxyFile;
+
+@SuppressWarnings("NotNullFieldNotInitialized")
+@Entity(tableName = "backup", primaryKeys = {"backup_name", "package_name"})
+public class Backup {
+    @ColumnInfo(name = "package_name")
+    @NonNull
+    public String packageName;
+
+    @ColumnInfo(name = "backup_name")
+    @NonNull
+    public String backupName;
+
+    @ColumnInfo(name = "label")
+    public String label;
+
+    @ColumnInfo(name = "version_name")
+    public String versionName;
+
+    @ColumnInfo(name = "version_code")
+    public long versionCode;
+
+    @ColumnInfo(name = "is_system")
+    public boolean isSystem;
+
+    @ColumnInfo(name = "has_splits")
+    public boolean hasSplits;
+
+    @ColumnInfo(name = "has_rules")
+    public boolean hasRules;
+
+    @ColumnInfo(name = "backup_time")
+    public long backupTime;
+
+    @ColumnInfo(name = "crypto")
+    @CryptoUtils.Mode
+    public String crypto;
+
+    @ColumnInfo(name = "meta_version")
+    public int version;
+
+    @ColumnInfo(name = "flags")
+    public int flags;
+
+    @ColumnInfo(name = "user_id")
+    public int userId;
+
+    @ColumnInfo(name = "tar_type")
+    @TarUtils.TarType
+    public String tarType;
+
+    @ColumnInfo(name = "has_key_store")
+    public boolean hasKeyStore;
+
+    @ColumnInfo(name = "installer_app")
+    public String installer;
+
+    public BackupFlags getFlags() {
+        return new BackupFlags(flags);
+    }
+
+    @NonNull
+    public File getBackupPath() {
+        return new ProxyFile(BackupFiles.getPackagePath(packageName), backupName);
+    }
+
+    public MetadataManager.Metadata getMetadata() throws JSONException {
+        MetadataManager metadataManager = MetadataManager.getNewInstance();
+        metadataManager.readMetadata(new BackupFiles.BackupFile((ProxyFile) getBackupPath(), false));
+        return metadataManager.getMetadata();
+    }
+
+    @NonNull
+    public static Backup fromBackupMetadata(@NonNull MetadataManager.Metadata metadata) {
+        Backup backup = new Backup();
+        backup.packageName = metadata.packageName;
+        backup.backupName = metadata.backupName;
+        backup.label = metadata.label;
+        backup.versionName = metadata.versionName;
+        backup.versionCode = metadata.versionCode;
+        backup.isSystem = metadata.isSystem;
+        backup.hasSplits = metadata.isSplitApk;
+        backup.hasRules = metadata.hasRules;
+        backup.backupTime = metadata.backupTime;
+        backup.crypto = metadata.crypto;
+        backup.version = metadata.version;
+        backup.flags = metadata.flags.getFlags();
+        backup.userId = metadata.userHandle;
+        backup.tarType = metadata.tarType;
+        backup.hasKeyStore = metadata.keyStore;
+        backup.installer = metadata.installer;
+        return backup;
+    }
+}

--- a/app/src/main/java/io/github/muntashirakon/AppManager/main/ApplicationItem.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/main/ApplicationItem.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 
 import aosp.libcore.util.EmptyArray;
 import io.github.muntashirakon.AppManager.backup.BackupManager;
-import io.github.muntashirakon.AppManager.backup.MetadataManager;
+import io.github.muntashirakon.AppManager.db.entity.Backup;
 import io.github.muntashirakon.AppManager.servermanager.PackageManagerCompat;
 import io.github.muntashirakon.AppManager.utils.PackageUtils;
 import io.github.muntashirakon.io.ProxyFile;
@@ -38,7 +38,7 @@ public class ApplicationItem extends PackageItemInfo {
      * Backup info
      */
     @Nullable
-    public MetadataManager.Metadata metadata;
+    public Backup backup;
     /**
      * Application flags.
      * See {@link android.content.pm.ApplicationInfo#flags}
@@ -135,9 +135,9 @@ public class ApplicationItem extends PackageItemInfo {
             } catch (Exception ignore) {
             }
         }
-        if (metadata != null) {
+        if (backup != null) {
             try {
-                ProxyFile iconFile = new ProxyFile(metadata.backupPath, BackupManager.ICON_FILE);
+                ProxyFile iconFile = new ProxyFile(backup.getBackupPath(), BackupManager.ICON_FILE);
                 if (iconFile.exists()) {
                     try (InputStream is = new ProxyInputStream(iconFile)) {
                         return Drawable.createFromStream(is, name);

--- a/app/src/main/java/io/github/muntashirakon/AppManager/main/MainRecyclerAdapter.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/main/MainRecyclerAdapter.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.github.muntashirakon.AppManager.R;
 import io.github.muntashirakon.AppManager.apk.installer.PackageInstallerActivity;
-import io.github.muntashirakon.AppManager.backup.MetadataManager;
+import io.github.muntashirakon.AppManager.db.entity.Backup;
 import io.github.muntashirakon.AppManager.details.AppDetailsActivity;
 import io.github.muntashirakon.AppManager.imagecache.ImageLoader;
 import io.github.muntashirakon.AppManager.settings.FeatureController;
@@ -334,14 +334,14 @@ public class MainRecyclerAdapter extends RecyclerView.Adapter<MainRecyclerAdapte
             holder.size.setTextColor(mColorOrange);
         } else holder.size.setTextColor(mColorSecondary);
         // Check for backup
-        if (item.metadata != null) {
+        if (item.backup != null) {
             holder.backupIndicator.setVisibility(View.VISIBLE);
             holder.backupInfo.setVisibility(View.VISIBLE);
             holder.backupInfoExt.setVisibility(View.VISIBLE);
             holder.backupIndicator.setText(R.string.backup);
             int indicatorColor;
             if (item.isInstalled) {
-                if (item.metadata.versionCode >= item.versionCode) {
+                if (item.backup.versionCode >= item.versionCode) {
                     // Up-to-date backup
                     indicatorColor = mColorStopped;
                 } else {
@@ -353,20 +353,20 @@ public class MainRecyclerAdapter extends RecyclerView.Adapter<MainRecyclerAdapte
                 indicatorColor = mColorRed;
             }
             holder.backupIndicator.setTextColor(indicatorColor);
-            MetadataManager.Metadata metadata = item.metadata;
+            Backup backup = item.backup;
             long days = TimeUnit.DAYS.convert(System.currentTimeMillis() -
-                    metadata.backupTime, TimeUnit.MILLISECONDS);
+                    backup.backupTime, TimeUnit.MILLISECONDS);
             holder.backupInfo.setText(String.format("%s: %s, %s %s",
                     mActivity.getString(R.string.latest_backup), mActivity.getResources()
                             .getQuantityString(R.plurals.usage_days, (int) days, days),
-                    mActivity.getString(R.string.version), metadata.versionName));
+                    mActivity.getString(R.string.version), backup.versionName));
             StringBuilder extBulder = new StringBuilder();
-            if (metadata.flags.backupApkFiles()) extBulder.append("apk");
-            if (metadata.flags.backupData()) {
+            if (backup.getFlags().backupApkFiles()) extBulder.append("apk");
+            if (backup.getFlags().backupData()) {
                 if (extBulder.length() > 0) extBulder.append("+");
                 extBulder.append("data");
             }
-            if (metadata.hasRules) {
+            if (backup.hasRules) {
                 if (extBulder.length() > 0) extBulder.append("+");
                 extBulder.append("rules");
             }

--- a/app/src/main/java/io/github/muntashirakon/AppManager/oneclickops/RestoreTasksDialogFragment.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/oneclickops/RestoreTasksDialogFragment.java
@@ -8,20 +8,20 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 
-import com.google.android.material.dialog.MaterialAlertDialogBuilder;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import io.github.muntashirakon.AppManager.R;
 import io.github.muntashirakon.AppManager.backup.BackupDialogFragment;
-import io.github.muntashirakon.AppManager.backup.BackupUtils;
-import io.github.muntashirakon.AppManager.backup.MetadataManager;
 import io.github.muntashirakon.AppManager.main.ApplicationItem;
 import io.github.muntashirakon.AppManager.types.SearchableMultiChoiceDialogBuilder;
 import io.github.muntashirakon.AppManager.utils.PackageUtils;
@@ -30,6 +30,7 @@ public class RestoreTasksDialogFragment extends DialogFragment {
     public static final String TAG = "RestoreTasksDialogFragment";
 
     private OneClickOpsActivity activity;
+    private final ExecutorService executor = Executors.newFixedThreadPool(2);
 
     @NonNull
     @Override
@@ -41,70 +42,70 @@ public class RestoreTasksDialogFragment extends DialogFragment {
         View view = inflater.inflate(R.layout.dialog_restore_tasks, null);
         // Restore all apps
         view.findViewById(R.id.restore_all).setOnClickListener(v -> {
-            if (isDetached()) return;
             activity.mProgressIndicator.show();
-            new Thread(() -> {
-                if (isDetached()) return;
-                HashMap<String, MetadataManager.Metadata> backupMetadata = BackupUtils.getAllBackupMetadata();
+            executor.submit(() -> {
+                if (isDetached() || Thread.currentThread().isInterrupted()) return;
                 List<ApplicationItem> applicationItems = new ArrayList<>();
                 List<CharSequence> applicationLabels = new ArrayList<>();
-                for (ApplicationItem item : PackageUtils.getInstalledOrBackedUpApplicationsFromDb(requireContext(), backupMetadata)) {
-                    if (isDetached()) return;
-                    if (item.metadata != null) {
+                for (ApplicationItem item : PackageUtils.getInstalledOrBackedUpApplicationsFromDb(requireContext(), null, true)) {
+                    if (isDetached() || Thread.currentThread().isInterrupted()) return;
+                    if (item.backup != null) {
                         applicationItems.add(item);
                         applicationLabels.add(item.label);
                     }
                 }
-                if (isDetached()) return;
+                if (isDetached() || Thread.currentThread().isInterrupted()) return;
                 requireActivity().runOnUiThread(() -> runMultiChoiceDialog(applicationItems, applicationLabels));
-            }).start();
+            });
         });
         // Restore not installed
         view.findViewById(R.id.restore_not_installed).setOnClickListener(v -> {
-            if (isDetached()) return;
             activity.mProgressIndicator.show();
-            new Thread(() -> {
-                if (isDetached()) return;
-                HashMap<String, MetadataManager.Metadata> backupMetadata = BackupUtils.getAllBackupMetadata();
+            executor.submit(() -> {
+                if (isDetached() || Thread.currentThread().isInterrupted()) return;
                 List<ApplicationItem> applicationItems = new ArrayList<>();
                 List<CharSequence> applicationLabels = new ArrayList<>();
-                for (ApplicationItem item : PackageUtils.getInstalledOrBackedUpApplicationsFromDb(requireContext(), backupMetadata)) {
-                    if (isDetached()) return;
-                    if (!item.isInstalled && item.metadata != null) {
+                for (ApplicationItem item : PackageUtils.getInstalledOrBackedUpApplicationsFromDb(requireContext(), null, true)) {
+                    if (isDetached() || Thread.currentThread().isInterrupted()) return;
+                    if (!item.isInstalled && item.backup != null) {
                         applicationItems.add(item);
                         applicationLabels.add(item.label);
                     }
                 }
-                if (isDetached()) return;
+                if (isDetached() || Thread.currentThread().isInterrupted()) return;
                 requireActivity().runOnUiThread(() -> runMultiChoiceDialog(applicationItems, applicationLabels));
-            }).start();
+            });
         });
         // Restore latest versions only
         view.findViewById(R.id.restore_latest).setOnClickListener(v -> {
-            if (isDetached()) return;
             activity.mProgressIndicator.show();
-            new Thread(() -> {
-                if (isDetached()) return;
-                HashMap<String, MetadataManager.Metadata> backupMetadata = BackupUtils.getAllBackupMetadata();
+            executor.submit(() -> {
+                if (isDetached() || Thread.currentThread().isInterrupted()) return;
                 List<ApplicationItem> applicationItems = new ArrayList<>();
                 List<CharSequence> applicationLabels = new ArrayList<>();
-                for (ApplicationItem item : PackageUtils.getInstalledOrBackedUpApplicationsFromDb(requireContext(), backupMetadata)) {
-                    if (isDetached()) return;
-                    if (item.isInstalled && item.metadata != null
-                            && item.versionCode < item.metadata.versionCode) {
+                for (ApplicationItem item : PackageUtils.getInstalledOrBackedUpApplicationsFromDb(requireContext(), null, true)) {
+                    if (isDetached() || Thread.currentThread().isInterrupted()) return;
+                    if (item.isInstalled && item.backup != null
+                            && item.versionCode < item.backup.versionCode) {
                         applicationItems.add(item);
                         applicationLabels.add(item.label);
                     }
                 }
-                if (isDetached()) return;
+                if (isDetached() || Thread.currentThread().isInterrupted()) return;
                 requireActivity().runOnUiThread(() -> runMultiChoiceDialog(applicationItems, applicationLabels));
-            }).start();
+            });
         });
         return new MaterialAlertDialogBuilder(requireActivity())
                 .setView(view)
                 .setTitle(R.string.restore)
                 .setNegativeButton(R.string.cancel, null)
                 .create();
+    }
+
+    @Override
+    public void onDestroy() {
+        executor.shutdownNow();
+        super.onDestroy();
     }
 
     @UiThread


### PR DESCRIPTION
* Backup information are always loaded from the database
* Backup metadata are read from the disk only when a new backup is made or an
  old backup is deleted or explicitly specified
* Backup metadata are always loaded from a background thread. Except in the
  1-click ops page, the loading process is fully transparent.