### PR TITLE
Disabling components of test only apps adb mode

### DIFF
--- a/app/src/main/java/io/github/muntashirakon/AppManager/oneclickops/OneClickOpsActivity.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/oneclickops/OneClickOpsActivity.java
@@ -89,24 +89,28 @@ public class OneClickOpsActivity extends BaseActivity {
 
     private void setItems() {
         mItemCreator.addItemWithTitleSubtitle(getString(R.string.block_unblock_trackers),
-                        getString(R.string.block_unblock_trackers_description))
+                getString(R.string.block_unblock_trackers_description))
                 .setOnClickListener(v -> {
-                    if (!AppPref.isRootEnabled()) {
-                        Toast.makeText(this, R.string.only_works_in_root_mode, Toast.LENGTH_SHORT).show();
-                        return;
+                    if (!AppPref.isRootOrAdbEnabled()) {
+                        Toast.makeText(this, R.string.only_works_in_root_or_adb_mode, Toast.LENGTH_SHORT).show();
+
+                    } else if (AppPref.isRootEnabled()) {
+                        new MaterialAlertDialogBuilder(this)
+                                .setTitle(R.string.block_unblock_trackers)
+                                .setMessage(R.string.apply_to_system_apps_question)
+                                .setPositiveButton(R.string.no, (dialog, which) -> blockTrackers(false, false))
+                                .setNegativeButton(R.string.yes, ((dialog, which) -> blockTrackers(true, false)))
+                                .show();
+                    } else if (AppPref.isAdbEnabled()) {
+                        blockTrackers(false, true);
                     }
-                    new MaterialAlertDialogBuilder(this)
-                            .setTitle(R.string.block_unblock_trackers)
-                            .setMessage(R.string.apply_to_system_apps_question)
-                            .setPositiveButton(R.string.no, (dialog, which) -> blockTrackers(false))
-                            .setNegativeButton(R.string.yes, ((dialog, which) -> blockTrackers(true)))
-                            .show();
+
                 });
         mItemCreator.addItemWithTitleSubtitle(getString(R.string.block_components_dots),
-                        getString(R.string.block_components_description))
+                getString(R.string.block_components_description))
                 .setOnClickListener(v -> blockComponents());
         mItemCreator.addItemWithTitleSubtitle(getString(R.string.set_mode_for_app_ops_dots),
-                        getString(R.string.deny_app_ops_description))
+                getString(R.string.deny_app_ops_description))
                 .setOnClickListener(v -> blockAppOps());
         mItemCreator.addItemWithTitleSubtitle(getText(R.string.back_up),
                 getText(R.string.backup_msg)).setOnClickListener(v ->
@@ -118,14 +122,14 @@ public class OneClickOpsActivity extends BaseActivity {
                         RestoreTasksDialogFragment.TAG));
         if (BuildConfig.DEBUG) {
             mItemCreator.addItemWithTitleSubtitle(getString(R.string.clear_data_from_uninstalled_apps),
-                            getString(R.string.clear_data_from_uninstalled_apps_description))
+                    getString(R.string.clear_data_from_uninstalled_apps_description))
                     .setOnClickListener(v -> clearData());
             mItemCreator.addItemWithTitleSubtitle(getString(R.string.clear_app_cache),
-                            getString(R.string.clear_app_cache_description))
+                    getString(R.string.clear_app_cache_description))
                     .setOnClickListener(v -> clearAppCache());
         }
         mItemCreator.addItemWithTitleSubtitle(getString(R.string.trim_caches_in_all_apps),
-                        getString(R.string.trim_caches_in_all_apps_description))
+                getString(R.string.trim_caches_in_all_apps_description))
                 .setOnClickListener(v -> trimCaches());
         mProgressIndicator.hide();
     }
@@ -144,7 +148,7 @@ public class OneClickOpsActivity extends BaseActivity {
     }
 
     @SuppressLint("WrongConstant")
-    private void blockTrackers(final boolean systemApps) {
+    private void blockTrackers(final boolean systemApps, final boolean adb) {
         mProgressIndicator.show();
         executor.submit(() -> {
             final List<ItemCount> trackerCounts = new ArrayList<>();
@@ -156,10 +160,20 @@ public class OneClickOpsActivity extends BaseActivity {
                         UserHandleHidden.myUserId())) {
                     if (Thread.currentThread().isInterrupted()) return;
                     ApplicationInfo applicationInfo = packageInfo.applicationInfo;
-                    if (!systemApps && (applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0)
-                        continue;
-                    trackerCount = ComponentUtils.getTrackerCountForApp(packageInfo);
-                    if (trackerCount.count > 0) trackerCounts.add(trackerCount);
+
+                    if (adb) {
+                        if ((applicationInfo.flags & ApplicationInfo.FLAG_TEST_ONLY) == ApplicationInfo.FLAG_TEST_ONLY) {
+                            trackerCount = ComponentUtils.getTrackerCountForApp(packageInfo);
+                            if (trackerCount.count > 0) trackerCounts.add(trackerCount);
+                            Log.d("ADB: ", "true");
+                        }
+                    } else {
+                        Log.d("ROOT: ", "true");
+                        if (!systemApps && (applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0)
+                            continue;
+                        trackerCount = ComponentUtils.getTrackerCountForApp(packageInfo);
+                        if (trackerCount.count > 0) trackerCounts.add(trackerCount);
+                    }
                 }
             } catch (RemoteException e) {
                 Log.e("OCOA", e);
@@ -213,80 +227,151 @@ public class OneClickOpsActivity extends BaseActivity {
     }
 
     private void blockComponents() {
-        if (!AppPref.isRootEnabled()) {
-            Toast.makeText(this, R.string.only_works_in_root_mode, Toast.LENGTH_SHORT).show();
-            return;
-        }
-        new TextInputDialogBuilder(this, R.string.input_signatures)
-                .setHelperText(R.string.input_signatures_description)
-                .setCheckboxLabel(R.string.apply_to_system_apps)
-                .setTitle(R.string.block_components_dots)
-                .setPositiveButton(R.string.search, (dialog, which, signatureNames, isChecked) -> {
-                    final boolean systemApps = isChecked;
-                    if (signatureNames == null) return;
-                    mProgressIndicator.show();
-                    executor.submit(() -> {
-                        String[] signatures = signatureNames.toString().split("\\s+");
-                        if (signatures.length == 0) return;
-                        final List<ItemCount> componentCounts = new ArrayList<>();
-                        for (ApplicationInfo applicationInfo : getPackageManager().getInstalledApplications(0)) {
-                            if (Thread.currentThread().isInterrupted()) return;
-                            if (!systemApps && (applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0)
-                                continue;
-                            ItemCount componentCount = new ItemCount();
-                            componentCount.packageName = applicationInfo.packageName;
-                            componentCount.packageLabel = applicationInfo.loadLabel(getPackageManager()).toString();
-                            componentCount.count = PackageUtils.getFilteredComponents(applicationInfo.packageName,
-                                    UserHandleHidden.myUserId(), signatures).size();
-                            if (componentCount.count > 0) componentCounts.add(componentCount);
-                        }
-                        if (!componentCounts.isEmpty()) {
-                            ItemCount componentCount;
-                            SpannableStringBuilder builder;
-                            final ArrayList<String> selectedPackages = new ArrayList<>();
-                            List<CharSequence> packageNamesWithComponentCount = new ArrayList<>();
-                            for (ItemCount count : componentCounts) {
+        if (!AppPref.isRootOrAdbEnabled()) {
+            Toast.makeText(this, R.string.only_works_in_root_or_adb_mode, Toast.LENGTH_SHORT).show();
+
+        } else if (AppPref.isRootEnabled()) {
+            new TextInputDialogBuilder(this, R.string.input_signatures)
+                    .setHelperText(R.string.input_signatures_description)
+                    .setCheckboxLabel(R.string.apply_to_system_apps)
+                    .setTitle(R.string.block_components_dots)
+                    .setPositiveButton(R.string.search, (dialog, which, signatureNames, isChecked) -> {
+                        final boolean systemApps = isChecked;
+                        if (signatureNames == null) return;
+                        mProgressIndicator.show();
+                        executor.submit(() -> {
+                            String[] signatures = signatureNames.toString().split("\\s+");
+                            if (signatures.length == 0) return;
+                            final List<ItemCount> componentCounts = new ArrayList<>();
+                            for (ApplicationInfo applicationInfo : getPackageManager().getInstalledApplications(0)) {
                                 if (Thread.currentThread().isInterrupted()) return;
-                                componentCount = count;
-                                builder = new SpannableStringBuilder(componentCount.packageLabel)
-                                        .append("\n").append(getSecondaryText(this,
-                                                getSmallerText(getResources().getQuantityString(
-                                                        R.plurals.no_of_components, componentCount.count,
-                                                        componentCount.count))));
-                                selectedPackages.add(componentCount.packageName);
-                                packageNamesWithComponentCount.add(builder);
+                                if (!systemApps && (applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0)
+                                    continue;
+                                ItemCount componentCount = new ItemCount();
+                                componentCount.packageName = applicationInfo.packageName;
+                                componentCount.packageLabel = applicationInfo.loadLabel(getPackageManager()).toString();
+                                componentCount.count = PackageUtils.getFilteredComponents(applicationInfo.packageName,
+                                        UserHandleHidden.myUserId(), signatures).size();
+                                if (componentCount.count > 0) componentCounts.add(componentCount);
                             }
-                            if (Thread.currentThread().isInterrupted()) return;
-                            runOnUiThread(() -> {
-                                mProgressIndicator.hide();
-                                new SearchableMultiChoiceDialogBuilder<>(this, selectedPackages, packageNamesWithComponentCount)
-                                        .setSelections(selectedPackages)
-                                        .setTitle(R.string.filtered_packages)
-                                        .setPositiveButton(R.string.apply, (dialog1, which1, selectedItems) -> {
-                                            mProgressIndicator.show();
-                                            Intent intent = new Intent(this, BatchOpsService.class);
-                                            intent.putStringArrayListExtra(BatchOpsService.EXTRA_OP_PKG, selectedItems);
-                                            intent.putExtra(BatchOpsService.EXTRA_OP, BatchOpsManager.OP_BLOCK_COMPONENTS);
-                                            intent.putExtra(BatchOpsService.EXTRA_HEADER, getString(R.string.one_click_ops));
-                                            Bundle args = new Bundle();
-                                            args.putStringArray(BatchOpsManager.ARG_SIGNATURES, signatures);
-                                            intent.putExtra(BatchOpsService.EXTRA_OP_EXTRA_ARGS, args);
-                                            ContextCompat.startForegroundService(this, intent);
-                                        })
-                                        .setNegativeButton(R.string.cancel, (dialog1, which1, selectedItems) -> mProgressIndicator.hide())
-                                        .show();
-                            });
-                        } else {
-                            if (Thread.currentThread().isInterrupted()) return;
-                            runOnUiThread(() -> {
-                                Toast.makeText(this, R.string.no_matching_package_found, Toast.LENGTH_SHORT).show();
-                                mProgressIndicator.hide();
-                            });
-                        }
-                    });
-                })
-                .setNegativeButton(R.string.cancel, null)
-                .show();
+                            if (!componentCounts.isEmpty()) {
+                                ItemCount componentCount;
+                                SpannableStringBuilder builder;
+                                final ArrayList<String> selectedPackages = new ArrayList<>();
+                                List<CharSequence> packageNamesWithComponentCount = new ArrayList<>();
+                                for (ItemCount count : componentCounts) {
+                                    if (Thread.currentThread().isInterrupted()) return;
+                                    componentCount = count;
+                                    builder = new SpannableStringBuilder(componentCount.packageLabel)
+                                            .append("\n").append(getSecondaryText(this,
+                                                    getSmallerText(getResources().getQuantityString(
+                                                            R.plurals.no_of_components, componentCount.count,
+                                                            componentCount.count))));
+                                    selectedPackages.add(componentCount.packageName);
+                                    packageNamesWithComponentCount.add(builder);
+                                }
+                                if (Thread.currentThread().isInterrupted()) return;
+                                runOnUiThread(() -> {
+                                    mProgressIndicator.hide();
+                                    new SearchableMultiChoiceDialogBuilder<>(this, selectedPackages, packageNamesWithComponentCount)
+                                            .setSelections(selectedPackages)
+                                            .setTitle(R.string.filtered_packages)
+                                            .setPositiveButton(R.string.apply, (dialog1, which1, selectedItems) -> {
+                                                mProgressIndicator.show();
+                                                Intent intent = new Intent(this, BatchOpsService.class);
+                                                intent.putStringArrayListExtra(BatchOpsService.EXTRA_OP_PKG, selectedItems);
+                                                intent.putExtra(BatchOpsService.EXTRA_OP, BatchOpsManager.OP_BLOCK_COMPONENTS);
+                                                intent.putExtra(BatchOpsService.EXTRA_HEADER, getString(R.string.one_click_ops));
+                                                Bundle args = new Bundle();
+                                                args.putStringArray(BatchOpsManager.ARG_SIGNATURES, signatures);
+                                                intent.putExtra(BatchOpsService.EXTRA_OP_EXTRA_ARGS, args);
+                                                ContextCompat.startForegroundService(this, intent);
+                                            })
+                                            .setNegativeButton(R.string.cancel, (dialog1, which1, selectedItems) -> mProgressIndicator.hide())
+                                            .show();
+                                });
+                            } else {
+                                if (Thread.currentThread().isInterrupted()) return;
+                                runOnUiThread(() -> {
+                                    Toast.makeText(this, R.string.no_matching_package_found, Toast.LENGTH_SHORT).show();
+                                    mProgressIndicator.hide();
+                                });
+                            }
+                        });
+                    })
+                    .setNegativeButton(R.string.cancel, null)
+                    .show();
+        } else if (AppPref.isAdbEnabled()) {
+            new TextInputDialogBuilder(this, R.string.input_signatures)
+                    .setHelperText(R.string.input_signatures_description)
+                    .setTitle(R.string.block_components_dots)
+                    .setPositiveButton(R.string.search, (dialog, which, signatureNames, isChecked) -> {
+                        if (signatureNames == null) return;
+                        mProgressIndicator.show();
+                        executor.submit(() -> {
+                            String[] signatures = signatureNames.toString().split("\\s+");
+                            if (signatures.length == 0) return;
+                            final List<ItemCount> componentCounts = new ArrayList<>();
+                            for (ApplicationInfo applicationInfo : getPackageManager().getInstalledApplications(0)) {
+                                if (Thread.currentThread().isInterrupted()) return;
+                                if ((applicationInfo.flags & ApplicationInfo.FLAG_TEST_ONLY) != ApplicationInfo.FLAG_TEST_ONLY)
+                                    continue;
+                                ItemCount componentCount = new ItemCount();
+                                componentCount.packageName = applicationInfo.packageName;
+                                componentCount.packageLabel = applicationInfo.loadLabel(getPackageManager()).toString();
+                                componentCount.count = PackageUtils.getFilteredComponents(applicationInfo.packageName,
+                                        UserHandleHidden.myUserId(), signatures).size();
+                                if (componentCount.count > 0) componentCounts.add(componentCount);
+                            }
+                            if (!componentCounts.isEmpty()) {
+                                ItemCount componentCount;
+                                SpannableStringBuilder builder;
+                                final ArrayList<String> selectedPackages = new ArrayList<>();
+                                List<CharSequence> packageNamesWithComponentCount = new ArrayList<>();
+                                for (ItemCount count : componentCounts) {
+                                    if (Thread.currentThread().isInterrupted()) return;
+                                    componentCount = count;
+                                    builder = new SpannableStringBuilder(componentCount.packageLabel)
+                                            .append("\n").append(getSecondaryText(this,
+                                                    getSmallerText(getResources().getQuantityString(
+                                                            R.plurals.no_of_components, componentCount.count,
+                                                            componentCount.count))));
+                                    selectedPackages.add(componentCount.packageName);
+                                    packageNamesWithComponentCount.add(builder);
+                                }
+                                if (Thread.currentThread().isInterrupted()) return;
+                                runOnUiThread(() -> {
+                                    mProgressIndicator.hide();
+                                    new SearchableMultiChoiceDialogBuilder<>(this, selectedPackages, packageNamesWithComponentCount)
+                                            .setSelections(selectedPackages)
+                                            .setTitle(R.string.filtered_packages)
+                                            .setPositiveButton(R.string.apply, (dialog1, which1, selectedItems) -> {
+                                                mProgressIndicator.show();
+                                                Intent intent = new Intent(this, BatchOpsService.class);
+                                                intent.putStringArrayListExtra(BatchOpsService.EXTRA_OP_PKG, selectedItems);
+                                                intent.putExtra(BatchOpsService.EXTRA_OP, BatchOpsManager.OP_BLOCK_COMPONENTS);
+                                                intent.putExtra(BatchOpsService.EXTRA_HEADER, getString(R.string.one_click_ops));
+                                                Bundle args = new Bundle();
+                                                args.putStringArray(BatchOpsManager.ARG_SIGNATURES, signatures);
+                                                intent.putExtra(BatchOpsService.EXTRA_OP_EXTRA_ARGS, args);
+                                                ContextCompat.startForegroundService(this, intent);
+                                            })
+                                            .setNegativeButton(R.string.cancel, (dialog1, which1, selectedItems) -> mProgressIndicator.hide())
+                                            .show();
+                                });
+                            } else {
+                                if (Thread.currentThread().isInterrupted()) return;
+                                runOnUiThread(() -> {
+                                    Toast.makeText(this, R.string.no_matching_package_found, Toast.LENGTH_SHORT).show();
+                                    mProgressIndicator.hide();
+                                });
+                            }
+                        });
+                    })
+                    .setNegativeButton(R.string.cancel, null)
+                    .show();
+        }
+
     }
 
     private void blockAppOps() {

--- a/app/src/main/java/io/github/muntashirakon/AppManager/rules/compontents/ComponentsBlocker.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/rules/compontents/ComponentsBlocker.java
@@ -417,7 +417,7 @@ public final class ComponentsBlocker extends RulesStorageManager {
      * available add them to the rules, overridden if necessary.
      */
     private void retrieveDisabledComponents() {
-        if (!AppPref.isRootEnabled()) return;
+        if (!AppPref.isRootOrAdbEnabled()) return;
         Log.d(TAG, "Retrieving disabled components for package " + packageName);
         if (!rulesFile.exists() || rulesFile.getBaseFile().length() == 0) {
             // System doesn't have any rules.


### PR DESCRIPTION
I have done these tasks from issue #511 

- In the 1-click ops page, enable “block/unblock trackers” and “block components...” for ADB users too, and filter the list with test-only the apps (for ADB users only, others should be the same as it is).

- In the ComponentsBlocker class, disable applying Intent Firewall (IFW) rules for ADB users

.