### PR TITLE
[Crypto] Add support for elliptic-curve cryptography (ECC)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     implementation 'com.github.MuntashirAkon:sun-security-android:1.1'
     implementation 'com.github.MuntashirAkon:libadb-android:2.2.0'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
     implementation 'com.github.MuntashirAkon.jadx:jadx-core:5a62a8e625'
     implementation 'com.github.MuntashirAkon.jadx:jadx-dex-input:5a62a8e625'
 

--- a/app/src/main/java/io/github/muntashirakon/AppManager/backup/CryptoUtils.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/backup/CryptoUtils.java
@@ -17,6 +17,7 @@ import io.github.muntashirakon.AppManager.crypto.AESCrypto;
 import io.github.muntashirakon.AppManager.crypto.Crypto;
 import io.github.muntashirakon.AppManager.crypto.CryptoException;
 import io.github.muntashirakon.AppManager.crypto.DummyCrypto;
+import io.github.muntashirakon.AppManager.crypto.ECCCrypto;
 import io.github.muntashirakon.AppManager.crypto.OpenPGPCrypto;
 import io.github.muntashirakon.AppManager.crypto.RSACrypto;
 import io.github.muntashirakon.AppManager.crypto.ks.KeyStoreManager;
@@ -56,6 +57,8 @@ public class CryptoUtils {
                 return AESCrypto.AES_EXT;
             case MODE_RSA:
                 return RSACrypto.RSA_EXT;
+            case MODE_ECC:
+                return ECCCrypto.ECC_EXT;
             case MODE_NO_ENCRYPTION:
             default:
                 return "";
@@ -78,12 +81,20 @@ public class CryptoUtils {
                 return new OpenPGPCrypto(metadata.keyIds);
             case MODE_AES:
                 return new AESCrypto(metadata.iv);
-            case MODE_RSA:
+            case MODE_RSA: {
                 RSACrypto rsaCrypto = new RSACrypto(metadata.iv, metadata.aes);
                 if (metadata.aes == null) {
                     metadata.aes = rsaCrypto.getEncryptedAesKey();
                 }
                 return rsaCrypto;
+            }
+            case MODE_ECC: {
+                ECCCrypto eccCrypto = new ECCCrypto(metadata.iv, metadata.aes);
+                if (metadata.aes == null) {
+                    metadata.aes = eccCrypto.getEncryptedAesKey();
+                }
+                return eccCrypto;
+            }
             case MODE_NO_ENCRYPTION:
             default:
                 // Dummy crypto to generalise and return nonNull
@@ -99,6 +110,7 @@ public class CryptoUtils {
                 break;
             case MODE_AES:
             case MODE_RSA:
+            case MODE_ECC:
                 SecureRandom random = new SecureRandom();
                 metadata.iv = new byte[AESCrypto.GCM_IV_LENGTH];
                 random.nextBytes(metadata.iv);
@@ -124,6 +136,12 @@ public class CryptoUtils {
             case MODE_RSA:
                 try {
                     return KeyStoreManager.getInstance().containsKey(RSACrypto.RSA_KEY_ALIAS);
+                } catch (Exception e) {
+                    return false;
+                }
+            case MODE_ECC:
+                try {
+                    return KeyStoreManager.getInstance().containsKey(ECCCrypto.ECC_KEY_ALIAS);
                 } catch (Exception e) {
                     return false;
                 }

--- a/app/src/main/java/io/github/muntashirakon/AppManager/backup/MetadataManager.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/backup/MetadataManager.java
@@ -307,6 +307,7 @@ public final class MetadataManager {
                 mMetadata.keyIds = rootObj.getString("key_ids");
                 break;
             case CryptoUtils.MODE_RSA:
+            case CryptoUtils.MODE_ECC:
                 mMetadata.aes = HexEncoding.decode(rootObj.getString("aes"));
                 // Deliberate fallthrough
             case CryptoUtils.MODE_AES:

--- a/app/src/main/java/io/github/muntashirakon/AppManager/crypto/AESCrypto.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/crypto/AESCrypto.java
@@ -3,6 +3,7 @@
 package io.github.muntashirakon.AppManager.crypto;
 
 import androidx.annotation.AnyThread;
+import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
@@ -34,16 +35,14 @@ public class AESCrypto implements Crypto {
     public static final String TAG = "AESCrypto";
 
     public static final String AES_EXT = ".aes";
-
     public static final String AES_KEY_ALIAS = "backup_aes";
-
     public static final int GCM_IV_LENGTH = 12; // in bytes
 
-    private final SecretKey secretKey;
-    private final AEADParameters spec;
+    private final SecretKey mSecretKey;
+    private final AEADParameters mParameters;
     @CryptoUtils.Mode
-    private final String parentMode;
-    private final List<Path> newFiles = new ArrayList<>();
+    private final String mParentMode;
+    private final List<Path> mNewFiles = new ArrayList<>();
 
     public AESCrypto(@NonNull byte[] iv) throws CryptoException {
         this(iv, CryptoUtils.MODE_AES, null);
@@ -51,37 +50,53 @@ public class AESCrypto implements Crypto {
 
     protected AESCrypto(@NonNull byte[] iv, @NonNull @CryptoUtils.Mode String mode, @Nullable byte[] encryptedAesKey)
             throws CryptoException {
-        this.parentMode = mode;
-        if (parentMode.equals(CryptoUtils.MODE_AES)) {
-            try {
-                KeyStoreManager keyStoreManager = KeyStoreManager.getInstance();
-                this.secretKey = keyStoreManager.getSecretKey(AES_KEY_ALIAS);
-                if (this.secretKey == null) {
-                    throw new CryptoException("No SecretKey with alias " + AES_KEY_ALIAS);
+        mParentMode = mode;
+        switch (mParentMode) {
+            case CryptoUtils.MODE_AES:
+                try {
+                    KeyStoreManager keyStoreManager = KeyStoreManager.getInstance();
+                    mSecretKey = keyStoreManager.getSecretKey(AES_KEY_ALIAS);
+                    if (mSecretKey == null) {
+                        throw new CryptoException("No SecretKey with alias " + AES_KEY_ALIAS);
+                    }
+                } catch (Exception e) {
+                    throw new CryptoException(e);
                 }
-            } catch (Exception e) {
-                throw new CryptoException(e);
-            }
-        } else if (parentMode.equals(CryptoUtils.MODE_RSA)) {
-            // Hybrid encryption using RSA
-            if (encryptedAesKey == null) {
-                // No encryption key provided, generate one
-                this.secretKey = RSACrypto.generateAesKey();
-            } else {
-                // Encryption key provided
-                this.secretKey = RSACrypto.decryptAesKey(encryptedAesKey);
-            }
-        } else {
-            throw new CryptoException("Unsupported mode " + parentMode);
+                break;
+            case CryptoUtils.MODE_RSA:
+                // Hybrid encryption using RSA
+                if (encryptedAesKey == null) {
+                    // No encryption key provided, generate one
+                    mSecretKey = RSACrypto.generateAesKey();
+                } else {
+                    // Encryption key provided
+                    mSecretKey = RSACrypto.decryptAesKey(encryptedAesKey);
+                }
+                break;
+            case CryptoUtils.MODE_ECC:
+                // Hybrid encryption using ECC
+                if (encryptedAesKey == null) {
+                    // No encryption key provided, generate one
+                    mSecretKey = ECCCrypto.generateAesKey();
+                } else {
+                    // Encryption key provided
+                    mSecretKey = ECCCrypto.decryptAesKey(encryptedAesKey);
+                }
+                break;
+            default:
+                throw new CryptoException("Unsupported mode " + mParentMode);
         }
-        this.spec = new AEADParameters(new KeyParameter(secretKey.getEncoded()), secretKey.getEncoded().length, iv);
+        mParameters = new AEADParameters(new KeyParameter(mSecretKey.getEncoded()), mSecretKey.getEncoded().length, iv);
     }
 
+    @CallSuper
     @Nullable
     protected byte[] getEncryptedAesKey() {
         try {
-            if (parentMode.equals(CryptoUtils.MODE_RSA)) {
-                return RSACrypto.encryptAesKey(secretKey);
+            if (mParentMode.equals(CryptoUtils.MODE_RSA)) {
+                return RSACrypto.encryptAesKey(mSecretKey);
+            } else if (mParentMode.equals(CryptoUtils.MODE_ECC)) {
+                return ECCCrypto.encryptAesKey(mSecretKey);
             }
         } catch (CryptoException e) {
             Log.e(TAG, e);
@@ -100,7 +115,7 @@ public class AESCrypto implements Crypto {
             throws IOException {
         // Init cipher
         GCMBlockCipher cipher = new GCMBlockCipher(new AESEngine());
-        cipher.init(true, spec);
+        cipher.init(true, mParameters);
         // Convert unencrypted stream to encrypted stream
         try (OutputStream cipherOS = new CipherOutputStream(encryptedStream, cipher)) {
             FileUtils.copy(unencryptedStream, cipherOS);
@@ -118,7 +133,7 @@ public class AESCrypto implements Crypto {
             throws IOException {
         // Init cipher
         GCMBlockCipher cipher = new GCMBlockCipher(new AESEngine());
-        cipher.init(false, spec);
+        cipher.init(false, mParameters);
         // Convert encrypted stream to unencrypted stream
         try (InputStream cipherIS = new CipherInputStream(encryptedStream, cipher)) {
             FileUtils.copy(cipherIS, unencryptedStream);
@@ -127,7 +142,7 @@ public class AESCrypto implements Crypto {
 
     @WorkerThread
     private void handleFiles(boolean forEncryption, @NonNull Path[] files) throws IOException {
-        newFiles.clear();
+        mNewFiles.clear();
         // `files` is never null here
         if (files.length == 0) {
             Log.d(TAG, "No files to de/encrypt");
@@ -135,9 +150,9 @@ public class AESCrypto implements Crypto {
         }
         // Init cipher
         GCMBlockCipher cipher = new GCMBlockCipher(new AESEngine());
-        cipher.init(forEncryption, spec);
+        cipher.init(forEncryption, mParameters);
         // Get desired extension
-        String ext = CryptoUtils.getExtension(parentMode);
+        String ext = CryptoUtils.getExtension(mParentMode);
         // Encrypt/decrypt files
         for (Path inputPath : files) {
             Path parent = inputPath.getParentFile();
@@ -149,7 +164,7 @@ public class AESCrypto implements Crypto {
                 outputFilename = inputPath.getName().substring(0, inputPath.getName().lastIndexOf(ext));
             } else outputFilename = inputPath.getName() + ext;
             Path outputPath = parent.createNewFile(outputFilename, null);
-            newFiles.add(outputPath);
+            mNewFiles.add(outputPath);
             Log.i(TAG, "Input: " + inputPath + "\nOutput: " + outputPath);
             try (InputStream is = inputPath.openInputStream();
                  OutputStream os = outputPath.openOutputStream()) {
@@ -177,13 +192,13 @@ public class AESCrypto implements Crypto {
     @NonNull
     @Override
     public Path[] getNewFiles() {
-        return newFiles.toArray(new Path[0]);
+        return mNewFiles.toArray(new Path[0]);
     }
 
     @Override
     public void close() {
         try {
-            SecretKeyCompat.destroy(secretKey);
+            SecretKeyCompat.destroy(mSecretKey);
         } catch (DestroyFailedException e) {
             e.printStackTrace();
         }

--- a/app/src/main/java/io/github/muntashirakon/AppManager/crypto/ECCCrypto.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/crypto/ECCCrypto.java
@@ -5,6 +5,8 @@ package io.github.muntashirakon.AppManager.crypto;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -20,22 +22,21 @@ import io.github.muntashirakon.AppManager.backup.CryptoUtils;
 import io.github.muntashirakon.AppManager.crypto.ks.KeyPair;
 import io.github.muntashirakon.AppManager.crypto.ks.KeyStoreManager;
 
-public class RSACrypto extends AESCrypto {
-    public static final String TAG = "RSACrypto";
+public class ECCCrypto extends AESCrypto {
+    public static final String TAG = "ECCCrypto";
 
-    public static final String RSA_EXT = ".rsa";
-    public static final String RSA_KEY_ALIAS = "backup_rsa";
+    public static final String ECC_EXT = ".ecc";
+    public static final String ECC_KEY_ALIAS = "backup_ecc";
 
-    private static final String RSA_CIPHER_TYPE = "RSA/NONE/OAEPPadding";  // 42 bytes padding
+    private static final String ECC_CIPHER_TYPE = "ECIES";
     private static final int AES_KEY_SIZE_BITS = 256;
 
-    public RSACrypto(@NonNull byte[] iv, @Nullable byte[] encryptedAesKey) throws CryptoException {
-        // This class extends AES crypto as RSA uses hybrid encryption
-        super(iv, CryptoUtils.MODE_RSA, encryptedAesKey);
+    public ECCCrypto(@NonNull byte[] iv, @Nullable byte[] encryptedAesKey) throws CryptoException {
+        super(iv, CryptoUtils.MODE_ECC, encryptedAesKey);
     }
 
-    @Override
     @Nullable
+    @Override
     public byte[] getEncryptedAesKey() {
         return super.getEncryptedAesKey();
     }
@@ -50,20 +51,18 @@ public class RSACrypto extends AESCrypto {
 
     @NonNull
     static SecretKey decryptAesKey(@NonNull byte[] encryptedAesKey) throws CryptoException {
-        // We only have 32/64 bytes AES key with either 256 or 512 bytes minus 42 bytes of data,
-        // so it should work without issues
         KeyPair keyPair;
         try {
             KeyStoreManager keyStoreManager = KeyStoreManager.getInstance();
-            keyPair = keyStoreManager.getKeyPair(RSA_KEY_ALIAS);
+            keyPair = keyStoreManager.getKeyPair(ECC_KEY_ALIAS);
             if (keyPair == null) {
-                throw new CryptoException("No KeyPair with alias " + RSA_KEY_ALIAS);
+                throw new CryptoException("No KeyPair with alias " + ECC_KEY_ALIAS);
             }
         } catch (Exception e) {
             throw new CryptoException(e);
         }
         try {
-            Cipher cipher = Cipher.getInstance(RSA_CIPHER_TYPE);
+            Cipher cipher = Cipher.getInstance(ECC_CIPHER_TYPE, new BouncyCastleProvider());
             cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivateKey());
             return new SecretKeySpec(cipher.doFinal(encryptedAesKey), "AES");
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | BadPaddingException
@@ -74,20 +73,18 @@ public class RSACrypto extends AESCrypto {
 
     @NonNull
     static byte[] encryptAesKey(@NonNull SecretKey key) throws CryptoException {
-        // We only have 32/64 bytes AES key with either 256 or 512 bytes minus 42 bytes of data,
-        // so it should work without issues
         KeyPair keyPair;
         try {
             KeyStoreManager keyStoreManager = KeyStoreManager.getInstance();
-            keyPair = keyStoreManager.getKeyPair(RSA_KEY_ALIAS);
+            keyPair = keyStoreManager.getKeyPair(ECC_KEY_ALIAS);
             if (keyPair == null) {
-                throw new CryptoException("No KeyPair with alias " + RSA_KEY_ALIAS);
+                throw new CryptoException("No KeyPair with alias " + ECC_KEY_ALIAS);
             }
         } catch (Exception e) {
             throw new CryptoException(e);
         }
         try {
-            Cipher cipher = Cipher.getInstance(RSA_CIPHER_TYPE);
+            Cipher cipher = Cipher.getInstance(ECC_CIPHER_TYPE, new BouncyCastleProvider());
             cipher.init(Cipher.ENCRYPT_MODE, keyPair.getPublicKey());
             return cipher.doFinal(key.getEncoded());
         } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException | BadPaddingException

--- a/app/src/main/java/io/github/muntashirakon/AppManager/settings/BackupRestorePreferences.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/settings/BackupRestorePreferences.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;
-import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -40,6 +39,7 @@ import io.github.muntashirakon.AppManager.batchops.BatchOpsService;
 import io.github.muntashirakon.AppManager.crypto.RSACrypto;
 import io.github.muntashirakon.AppManager.db.utils.AppDb;
 import io.github.muntashirakon.AppManager.settings.crypto.AESCryptoSelectionDialogFragment;
+import io.github.muntashirakon.AppManager.settings.crypto.ECCCryptoSelectionDialogFragment;
 import io.github.muntashirakon.AppManager.settings.crypto.OpenPgpKeySelectionDialogFragment;
 import io.github.muntashirakon.AppManager.settings.crypto.RSACryptoSelectionDialogFragment;
 import io.github.muntashirakon.AppManager.utils.AppPref;
@@ -58,7 +58,7 @@ public class BackupRestorePreferences extends PreferenceFragment {
             R.string.open_pgp_provider,
             R.string.aes,
             R.string.rsa,
-            /* R.string.ecc, // TODO(01/04/21): Implement ECC */
+             R.string.ecc,
     };
 
     private SettingsActivity activity;
@@ -180,8 +180,13 @@ public class BackupRestorePreferences extends PreferenceFragment {
                                 break;
                             }
                             case CryptoUtils.MODE_ECC: {
-                                // TODO(01/04/21): Implement ECC
-                                Toast.makeText(activity, "Not implemented yet.", Toast.LENGTH_SHORT).show();
+                                ECCCryptoSelectionDialogFragment fragment = new ECCCryptoSelectionDialogFragment();
+                                fragment.setOnKeyPairUpdatedListener((keyPair, certificateBytes) -> {
+                                    if (keyPair != null) {
+                                        AppPref.set(AppPref.PrefKey.PREF_ENCRYPTION_STR, CryptoUtils.MODE_ECC);
+                                    }
+                                });
+                                fragment.show(getParentFragmentManager(), RSACryptoSelectionDialogFragment.TAG);
                                 break;
                             }
                             case CryptoUtils.MODE_OPEN_PGP: {

--- a/app/src/main/java/io/github/muntashirakon/AppManager/settings/crypto/ECCCryptoSelectionDialogFragment.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/settings/crypto/ECCCryptoSelectionDialogFragment.java
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package io.github.muntashirakon.AppManager.settings.crypto;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.widget.Button;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import androidx.annotation.WorkerThread;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+
+import io.github.muntashirakon.AppManager.R;
+import io.github.muntashirakon.AppManager.backup.CryptoUtils;
+import io.github.muntashirakon.AppManager.crypto.ECCCrypto;
+import io.github.muntashirakon.AppManager.crypto.ks.KeyPair;
+import io.github.muntashirakon.AppManager.crypto.ks.KeyStoreManager;
+import io.github.muntashirakon.AppManager.logs.Log;
+import io.github.muntashirakon.AppManager.utils.PackageUtils;
+import io.github.muntashirakon.AppManager.utils.UIUtils;
+import io.github.muntashirakon.dialog.ScrollableDialogBuilder;
+
+public class ECCCryptoSelectionDialogFragment extends DialogFragment {
+    public static final String TAG = ECCCryptoSelectionDialogFragment.class.getSimpleName();
+
+    public interface OnKeyPairUpdatedListener {
+        @UiThread
+        void keyPairUpdated(@Nullable KeyPair keyPair, @Nullable byte[] certificateBytes);
+    }
+
+    private FragmentActivity activity;
+    private ScrollableDialogBuilder builder;
+    @Nullable
+    private OnKeyPairUpdatedListener listener;
+    @Nullable
+    private KeyStoreManager keyStoreManager;
+    private final String targetAlias = ECCCrypto.ECC_KEY_ALIAS;
+
+    public void setOnKeyPairUpdatedListener(OnKeyPairUpdatedListener listener) {
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        activity = requireActivity();
+        builder = new ScrollableDialogBuilder(activity)
+                .setTitle(R.string.ecc)
+                .setPositiveButton(R.string.ok, null)
+                .setNegativeButton(R.string.pref_import, null)
+                .setNeutralButton(R.string.generate_key, null);
+        new Thread(() -> {
+            if (isDetached()) return;
+            CharSequence info = getSigningInfo();
+            activity.runOnUiThread(() -> builder.setMessage(info));
+        }).start();
+        AlertDialog alertDialog = builder.create();
+        alertDialog.setOnShowListener(dialog -> {
+            AlertDialog dialog1 = (AlertDialog) dialog;
+            Button defaultOrOkButton = dialog1.getButton(AlertDialog.BUTTON_POSITIVE);
+            Button importButton = dialog1.getButton(AlertDialog.BUTTON_NEGATIVE);
+            Button generateButton = dialog1.getButton(AlertDialog.BUTTON_NEUTRAL);
+            importButton.setOnClickListener(v -> {
+                KeyPairImporterDialogFragment fragment = new KeyPairImporterDialogFragment();
+                Bundle args = new Bundle();
+                args.putString(KeyPairImporterDialogFragment.EXTRA_ALIAS, targetAlias);
+                fragment.setArguments(args);
+                fragment.setOnKeySelectedListener((keyPair) -> new Thread(() ->
+                        new Thread(() -> addKeyPair(keyPair)).start()).start());
+                fragment.show(getParentFragmentManager(), KeyPairImporterDialogFragment.TAG);
+            });
+            generateButton.setOnClickListener(v -> {
+                KeyPairGeneratorDialogFragment fragment = new KeyPairGeneratorDialogFragment();
+                Bundle args = new Bundle();
+                args.putString(KeyPairGeneratorDialogFragment.EXTRA_KEY_TYPE, CryptoUtils.MODE_ECC);
+                fragment.setArguments(args);
+                fragment.setOnGenerateListener((keyPair) -> new Thread(() ->
+                        addKeyPair(keyPair)).start());
+                fragment.show(getParentFragmentManager(), KeyPairGeneratorDialogFragment.TAG);
+            });
+            defaultOrOkButton.setOnClickListener(v -> new Thread(() -> {
+                try {
+                    if (isDetached()) return;
+                    activity.runOnUiThread(() -> UIUtils.displayShortToast(R.string.done));
+                    keyPairUpdated();
+                } catch (Exception e) {
+                    Log.e(TAG, e);
+                    activity.runOnUiThread(() -> UIUtils.displayLongToast(R.string.failed_to_save_key));
+                } finally {
+                    alertDialog.dismiss();
+                }
+            }).start());
+        });
+        return alertDialog;
+    }
+
+    @WorkerThread
+    private CharSequence getSigningInfo() {
+        KeyPair keyPair = getKeyPair();
+        if (keyPair != null) {
+            try {
+                return PackageUtils.getSigningCertificateInfo(activity, (X509Certificate) keyPair.getCertificate());
+            } catch (CertificateEncodingException e) {
+                return getString(R.string.failed_to_load_key);
+            }
+        }
+        return getString(R.string.key_not_set);
+    }
+
+    @WorkerThread
+    private void addKeyPair(@Nullable KeyPair keyPair) {
+        try {
+            if (keyPair == null) {
+                throw new Exception("Keypair can't be null.");
+            }
+            keyStoreManager = KeyStoreManager.getInstance();
+            keyStoreManager.addKeyPair(targetAlias, keyPair, true);
+            if (isDetached()) return;
+            activity.runOnUiThread(() -> UIUtils.displayShortToast(R.string.done));
+            keyPairUpdated();
+            if (isDetached()) return;
+            CharSequence info = getSigningInfo();
+            activity.runOnUiThread(() -> builder.setMessage(info));
+        } catch (Exception e) {
+            Log.e(TAG, e);
+            activity.runOnUiThread(() -> UIUtils.displayLongToast(R.string.failed_to_save_key));
+        }
+    }
+
+    @WorkerThread
+    private void keyPairUpdated() {
+        try {
+            KeyPair keyPair = getKeyPair();
+            if (keyPair != null) {
+                if (listener != null) {
+                    byte[] bytes = keyPair.getCertificate().getEncoded();
+                    activity.runOnUiThread(() -> listener.keyPairUpdated(keyPair, bytes));
+                }
+                return;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, e);
+        }
+        if (listener != null) {
+            activity.runOnUiThread(() -> listener.keyPairUpdated(null, null));
+        }
+    }
+
+    @WorkerThread
+    @Nullable
+    private KeyPair getKeyPair() {
+        try {
+            keyStoreManager = KeyStoreManager.getInstance();
+            if (keyStoreManager.containsKey(targetAlias)) {
+                return keyStoreManager.getKeyPair(targetAlias);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, e);
+        }
+        return null;
+    }
+}

--- a/app/src/main/java/io/github/muntashirakon/AppManager/settings/crypto/KeyPairImporterDialogFragment.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/settings/crypto/KeyPairImporterDialogFragment.java
@@ -46,6 +46,7 @@ public class KeyPairImporterDialogFragment extends DialogFragment {
     @Nullable
     private OnKeySelectedListener listener;
     private FragmentActivity activity;
+    @KeyStoreUtils.KeyType
     private int keyType;
     @Nullable
     private Uri ksOrPemFile;
@@ -89,11 +90,11 @@ public class KeyPairImporterDialogFragment extends DialogFragment {
                 R.layout.support_simple_spinner_dropdown_item));
         keyTypeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+            public void onItemSelected(AdapterView<?> parent, View view, @KeyStoreUtils.KeyType int position, long id) {
                 ksPassOrPk8.setText(null);
                 ksLocationOrPem.setText(null);
 
-                if (position == 3) {
+                if (position == KeyStoreUtils.KeyType.PK8) {
                     // PKCS #8 and PEM
                     ksPassOrPk8Layout.setHint(R.string.pk8_file);
                     ksPassOrPk8.setKeyListener(null);
@@ -118,7 +119,7 @@ public class KeyPairImporterDialogFragment extends DialogFragment {
 
             @Override
             public void onNothingSelected(AdapterView<?> parent) {
-                keyType = 0;
+                keyType = KeyStoreUtils.KeyType.JKS;
                 // KeyStore
                 ksPassOrPk8Layout.setHint(R.string.keystore_pass);
                 ksPassOrPk8.setKeyListener(keyListener);
@@ -138,7 +139,7 @@ public class KeyPairImporterDialogFragment extends DialogFragment {
             Button okButton = dialog1.getButton(AlertDialog.BUTTON_POSITIVE);
             okButton.setOnClickListener(v -> {
                 if (listener == null) return;
-                if (keyType == 3) {
+                if (keyType == KeyStoreUtils.KeyType.PK8) {
                     // PKCS #8 and PEM
                     try {
                         if (pk8File == null || ksOrPemFile == null) {

--- a/app/src/main/java/io/github/muntashirakon/AppManager/settings/crypto/RSACryptoSelectionDialogFragment.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/settings/crypto/RSACryptoSelectionDialogFragment.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import io.github.muntashirakon.AppManager.R;
+import io.github.muntashirakon.AppManager.backup.CryptoUtils;
 import io.github.muntashirakon.AppManager.crypto.ks.KeyPair;
 import io.github.muntashirakon.AppManager.crypto.ks.KeyStoreManager;
 import io.github.muntashirakon.AppManager.logs.Log;
@@ -110,6 +111,9 @@ public class RSACryptoSelectionDialogFragment extends DialogFragment {
             });
             generateButton.setOnClickListener(v -> {
                 KeyPairGeneratorDialogFragment fragment = new KeyPairGeneratorDialogFragment();
+                Bundle args = new Bundle();
+                args.putString(KeyPairGeneratorDialogFragment.EXTRA_KEY_TYPE, CryptoUtils.MODE_RSA);
+                fragment.setArguments(args);
                 fragment.setOnGenerateListener(keyPair -> model.addKeyPair(targetAlias, keyPair));
                 fragment.show(getParentFragmentManager(), KeyPairGeneratorDialogFragment.TAG);
             });


### PR DESCRIPTION
ECC in App Manager uses curve 25519 with ECDH which is wrapped with
SHA512withECDSA when storing the key in the Bouncy Castle KeyStore.

Signed-off-by: Muntashir Al-Islam <muntashirakon@riseup.net>