### PR TITLE
[Main] Add option to sort the app list by size

### DIFF
--- a/app/src/main/java/io/github/muntashirakon/AppManager/main/ApplicationItem.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/main/ApplicationItem.java
@@ -84,6 +84,7 @@ public class ApplicationItem extends PackageItemInfo {
     public Integer blockedCount = 0;
     public Integer trackerCount = 0;
     public Long lastActionTime = 0L;
+    public Long totalSize = 0L;
     /**
      * Whether the item is a user app (or system app)
      */

--- a/app/src/main/java/io/github/muntashirakon/AppManager/main/ListOptions.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/main/ListOptions.java
@@ -47,6 +47,7 @@ public class ListOptions extends CapsuleBottomSheetDialogFragment {
             SORT_BY_TRACKERS,
             SORT_BY_LAST_ACTION,
             SORT_BY_INSTALLATION_DATE,
+            SORT_BY_TOTAL_SIZE,
     })
     @Retention(RetentionPolicy.SOURCE)
     public @interface SortOrder {
@@ -65,6 +66,7 @@ public class ListOptions extends CapsuleBottomSheetDialogFragment {
     public static final int SORT_BY_TRACKERS = 10;
     public static final int SORT_BY_LAST_ACTION = 11;
     public static final int SORT_BY_INSTALLATION_DATE = 12;
+    public static final int SORT_BY_TOTAL_SIZE = 13;
 
     @IntDef(flag = true, value = {
             FILTER_NO_FILTER,
@@ -100,7 +102,8 @@ public class ListOptions extends CapsuleBottomSheetDialogFragment {
     private static final int[] SORT_ITEMS_MAP = {R.string.sort_by_domain, R.string.sort_by_app_label,
             R.string.sort_by_package_name, R.string.sort_by_last_update, R.string.sort_by_shared_user_id,
             R.string.sort_by_target_sdk, R.string.sort_by_sha, R.string.sort_by_disabled_app,
-            R.string.sort_by_blocked_components, R.string.sort_by_backup, R.string.trackers, R.string.last_actions, R.string.sort_by_installation_date};
+            R.string.sort_by_blocked_components, R.string.sort_by_backup, R.string.trackers, R.string.last_actions,
+            R.string.sort_by_installation_date, R.string.sort_by_total_size};
     private static final SparseIntArray FILTER_MAP = new SparseIntArray() {{
         put(FILTER_USER_APPS, R.string.filter_user_apps);
         put(FILTER_SYSTEM_APPS, R.string.filter_system_apps);

--- a/app/src/main/java/io/github/muntashirakon/AppManager/utils/PackageUtils.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/utils/PackageUtils.java
@@ -230,6 +230,12 @@ public final class PackageUtils {
             item.blockedCount = app.rulesCount;
             item.trackerCount = app.trackerCount;
             item.lastActionTime = app.lastActionTime;
+            for (int userId : item.userHandles) {
+                PackageSizeInfo sizeInfo = getPackageSizeInfo(context, item.packageName, userId, null);
+                if (sizeInfo != null) {
+                    item.totalSize += sizeInfo.getTotalSize();
+                }
+            }
         }
         // Add rest of the backups
         for (String packageName : backups.keySet()) {
@@ -278,7 +284,7 @@ public final class PackageUtils {
 
     @WorkerThread
     @Nullable
-    public static PackageSizeInfo getPackageSizeInfo(Context context, String packageName, int userHandle, UUID storageUuid) {
+    public static PackageSizeInfo getPackageSizeInfo(@NonNull Context context, @NonNull String packageName, int userHandle, @Nullable UUID storageUuid) {
         AtomicReference<PackageSizeInfo> packageSizeInfo = new AtomicReference<>();
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             CountDownLatch waitForStats = new CountDownLatch(1);
@@ -303,7 +309,7 @@ public final class PackageUtils {
             try {
                 IStorageStatsManager storageStatsManager = IStorageStatsManager.Stub.asInterface(ProxyBinder
                         .getService(Context.STORAGE_STATS_SERVICE));
-                String uuidString = StorageManagerHidden.convert(storageUuid);
+                String uuidString = storageUuid != null ? StorageManagerHidden.convert(storageUuid) : null;
                 StorageStats storageStats = storageStatsManager.queryStatsForPackage(uuidString, packageName,
                         userHandle, context.getPackageName());
                 packageSizeInfo.set(new PackageSizeInfo(packageName, storageStats, userHandle));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1239,4 +1239,5 @@
     <string name="changelog_type_improve">Improve</string>
     <string name="unsupported_split_apk">Unsupported</string>
     <string name="view_changelog">Find out what\'s new in this release</string>
+    <string name="sort_by_total_size">Total size</string>
 </resources>


### PR DESCRIPTION
Sorting the app list by the size of the package adds additional costs to the
overall loading time. Loading time depends on the device configurations and the
amount of apps. But the overall performance should be degraded by a significant
number. Only size of the installed apps are considered for all the configured
users.

Signed-off-by: Muntashir Al-Islam <muntashirakon@riseup.net>