### PR TITLE
[Interceptor] Add option to copy as `am` command

### DIFF
--- a/app/src/main/java/io/github/muntashirakon/AppManager/intercept/ActivityInterceptor.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/intercept/ActivityInterceptor.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.UUID;
@@ -62,6 +63,7 @@ import io.github.muntashirakon.AppManager.crypto.auth.AuthManager;
 import io.github.muntashirakon.AppManager.details.LauncherIconCreator;
 import io.github.muntashirakon.AppManager.imagecache.ImageLoader;
 import io.github.muntashirakon.AppManager.logs.Log;
+import io.github.muntashirakon.AppManager.runner.RunnerUtils;
 import io.github.muntashirakon.AppManager.settings.Ops;
 import io.github.muntashirakon.AppManager.utils.PackageUtils;
 import io.github.muntashirakon.AppManager.utils.UIUtils;
@@ -786,6 +788,18 @@ public class ActivityInterceptor extends BaseActivity {
         UIUtils.displayShortToast(R.string.copied_to_clipboard);
     }
 
+    private void copyIntentAsCommand() {
+        if (mMutableIntent == null) {
+            return;
+        }
+        List<String> args = IntentCompat.flattenToCommand(mMutableIntent);
+        String command = String.format(Locale.ROOT, "%s start --user %d %s", RunnerUtils.CMD_AM, mUserHandle,
+                TextUtils.join(" ", args));
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+        clipboard.setPrimaryClip(ClipData.newPlainText("am command", command));
+        UIUtils.displayShortToast(R.string.copied_to_clipboard);
+    }
+
     private void pasteIntentDetails() {
         ClipboardManager clipboard = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
         ClipData clipData = clipboard.getPrimaryClip();
@@ -941,8 +955,11 @@ public class ActivityInterceptor extends BaseActivity {
         if (id == android.R.id.home) {
             finish();
             return true;
-        } else if (id == R.id.action_copy) {
+        } else if (id == R.id.action_copy_as_default) {
             copyIntentDetails();
+            return true;
+        } else if (id == R.id.action_copy_as_command) {
+            copyIntentAsCommand();
             return true;
         } else if (id == R.id.action_paste) {
             pasteIntentDetails();

--- a/app/src/main/res/menu/activity_activity_interceptor_actions.xml
+++ b/app/src/main/res/menu/activity_activity_interceptor_actions.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<?xml version="1.0" encoding="utf-8"?><!-- SPDX-License-Identifier: Apache-2.0 -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
@@ -7,7 +6,16 @@
         android:id="@+id/action_copy"
         android:icon="@drawable/ic_baseline_content_copy_24"
         android:title="@string/copy"
-        app:showAsAction="always" />
+        app:showAsAction="always">
+        <menu>
+            <item
+                android:id="@+id/action_copy_as_default"
+                android:title="@string/copy" />
+            <item
+                android:id="@+id/action_copy_as_command"
+                android:title="@string/am_command" />
+        </menu>
+    </item>
 
     <item
         android:id="@+id/action_paste"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1240,4 +1240,5 @@
     <string name="unsupported_split_apk">Unsupported</string>
     <string name="view_changelog">Find out what\'s new in this release</string>
     <string name="sort_by_total_size">Total size</string>
+    <string name="am_command"><tt>am</tt> command</string>
 </resources>


### PR DESCRIPTION
`am` (short for activity manager) or `cmd activity` (Android 9 and later) can
be used to start an activity from the terminal. This option let user copy the
Intent as an `am` command so that the same Intent can be invoked in the
terminal. But not all extras are supported, only the supported extras are
copied during the operation.

Signed-off-by: Muntashir Al-Islam <muntashirakon@riseup.net>