### PR TITLE
[Issue #1218] Fix ComponentBlocker on Android 14

### DIFF
--- a/app/src/main/java/io/github/muntashirakon/AppManager/compat/PackageManagerCompat.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/compat/PackageManagerCompat.java
@@ -298,7 +298,12 @@ public final class PackageManagerCompat {
                                                   @EnabledFlags int flags,
                                                   @UserIdInt int userId)
             throws RemoteException {
-        getPackageManager().setComponentEnabledSetting(componentName, newState, flags, userId);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            getPackageManager().setComponentEnabledSetting(componentName, newState, flags, userId, null);
+        }
+        else {
+            getPackageManager().setComponentEnabledSetting(componentName, newState, flags, userId);
+        }
         if (userId != UserHandleHidden.myUserId()) {
             BroadcastUtils.sendPackageAltered(ContextUtils.getContext(), new String[]{componentName.getPackageName()});
         }

--- a/hiddenapi/src/main/java/android/content/pm/IPackageManager.java
+++ b/hiddenapi/src/main/java/android/content/pm/IPackageManager.java
@@ -650,6 +650,12 @@ public interface IPackageManager extends IInterface {
     void setComponentEnabledSetting(ComponentName componentName, int newState, int flags, int userId) throws RemoteException;
 
     /**
+     * As per {@link android.content.pm.PackageManager#setComponentEnabledSetting}.
+     */
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    void setComponentEnabledSetting(ComponentName componentName, int newState, int flags, int userId, String callingPackage) throws RemoteException;
+
+    /**
      * As per {@link android.content.pm.PackageManager#getComponentEnabledSetting}.
      */
     int getComponentEnabledSetting(ComponentName componentName, int userId) throws RemoteException;

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 ext {
-    compile_sdk = 33
+    compile_sdk = 34
     min_sdk = 21
     target_sdk = 33
 


### PR DESCRIPTION
The method signature of the Adnroid PackageManager method "setComponentEnabledSetting" was updated in Android 14. The new method signature has an additional parameter "callingPackage".