### PR TITLE
Remove android:hasFragileUserData="true"

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -145,7 +145,6 @@
         android:dataExtractionRules="@xml/backup_rules"
         android:fullBackupContent="@xml/full_backup_rules"
         android:banner="@mipmap/ic_banner"
-        android:hasFragileUserData="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"


### PR DESCRIPTION
Remove android:hasFragileUserData="true" to close #1193 because it will crash Package Managers on some Android Phones.