### PR TITLE
Fix: potential integer overflow in check

### DIFF
--- a/app/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
+++ b/app/src/main/java/org/apache/commons/compress/archivers/tar/TarUtils.java
@@ -696,13 +696,16 @@ public class TarUtils {
                     while((ch = inputStream.read()) != -1) {
                         read++;
                         totalRead++;
+                        if (totalRead < 0 || (headerSize >= 0 && totalRead >= headerSize)) {
+                             break;
+                         }
                         if (ch == '='){ // end of keyword
                             final String keyword = coll.toString(CharsetNames.UTF_8);
                             // Get rest of entry
                             final int restLen = len - read;
                             if (restLen <= 1) { // only NL
                                 headers.remove(keyword);
-                            } else if (headerSize >= 0 && totalRead + restLen > headerSize) {
+                            } else if (headerSize >= 0 && restLen > headerSize - totalRead) {
                                 throw new IOException("Paxheader value size " + restLen
                                     + " exceeds size of header record");
 


### PR DESCRIPTION
This PR ports the integer overflow protection from Apache Commons Compress commit (https://github.com/apache/commons-compress/commit/7ce1b0796d6cbe1f41b969583bd49f33ae0efef0) to the copy of this library included in AppManager.

The original fix in TarUtils.java addressed an integer overflow vulnerability in the parsePaxHeaders method, but has not been applied here yet.

