### PR TITLE
Intercept some popular Chinese apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -832,10 +832,16 @@
                 <data android:scheme="view-source" />
                 <data android:scheme="sqlite" />
 
+                <!-- Intercept Alipay links -->
+                <data android:scheme="alipays" />
+
                 <!-- Intercept Google play links -->
                 <data android:scheme="market" />
                 <data android:scheme="store" />
                 <data android:scheme="android" />
+
+                <!-- Intercept WeChat links -->
+                <data android:scheme="weixin" />
 
                 <!-- Intercept WhatsApp links -->
                 <data android:scheme="whatsapp" />
@@ -893,10 +899,16 @@
                 <data android:scheme="view-source" />
                 <data android:scheme="sqlite" />
 
+                <!-- Intercept Alipay links -->
+                <data android:scheme="alipays" />
+
                 <!-- Intercept Google play links -->
                 <data android:scheme="market" />
                 <data android:scheme="store" />
                 <data android:scheme="android" />
+
+                <!-- Intercept WeChat links -->
+                <data android:scheme="weixin" />
 
                 <data android:mimeType="*/*" />
             </intent-filter>


### PR DESCRIPTION
This pull request allows App Manager to intercept some intent sent to two popular Chinese applications, Alipay and WeChat.

Btw, WhatsApp's url schemes is only added in the `scheme-intents without mime` section, while other url schemes are added to both sections, is that a bug?