### PR TITLE
SplitInputStream: close all underlying streams even if one close fails

### DIFF
--- a/libcore/io/src/main/java/io/github/muntashirakon/io/SplitInputStream.java
+++ b/libcore/io/src/main/java/io/github/muntashirakon/io/SplitInputStream.java
@@ -79,9 +79,19 @@ public class SplitInputStream extends InputStream {
 
     @Override
     public void close() throws IOException {
+        IOException failure = null;
         for (InputStream stream : mInputStreams) {
-            stream.close();
+            try {
+                stream.close();
+            } catch (IOException e) {
+                if (failure == null) {
+                    failure = e;
+                } else {
+                    failure.addSuppressed(e);
+                }
+            }
         }
+        if (failure != null) throw failure;
     }
 
     @Override


### PR DESCRIPTION
### Problem
`SplitInputStream` wraps multiple `InputStreams`. In `close()`, it closes them sequentially without handling exceptions. If one `close()` throws, the method exits immediately and the remaining streams are never closed.

### Fix
- Wrap each `stream.close()` in a `try/catch.`
- Continue closing the remaining streams even after a failure.
- After attempting all closes, throw the first exception (and attach later ones as suppressed, if present).