### PR TITLE
Fix SAF/VFS path resolution crash by using checked IOException instead of unchecked NPE

### DIFF
--- a/app/src/main/java/io/github/muntashirakon/AppManager/utils/ExUtils.java
+++ b/app/src/main/java/io/github/muntashirakon/AppManager/utils/ExUtils.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.Contract;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import io.github.muntashirakon.AppManager.backup.BackupException;
 import io.github.muntashirakon.AppManager.logs.Log;
@@ -28,6 +29,18 @@ public class ExUtils {
         void run() throws Throwable;
     }
 
+    @NonNull
+    public static <T> T requireNonNullOrThrow(
+            @Nullable T value,
+            @NonNull Supplier<? extends IOException> exceptionSupplier
+    ) throws IOException {
+        if (value == null) {
+            throw exceptionSupplier.get();
+        }
+        return value;
+    }
+
+    
     @Contract("_ -> fail")
     public static <T> T rethrowAsIOException(@NonNull Throwable e) throws IOException {
         IOException ioException = new IOException(e.getMessage());

--- a/app/src/main/java/io/github/muntashirakon/io/PathImpl.java
+++ b/app/src/main/java/io/github/muntashirakon/io/PathImpl.java
@@ -48,6 +48,7 @@ import io.github.muntashirakon.AppManager.compat.StorageManagerCompat;
 import io.github.muntashirakon.AppManager.ipc.LocalServices;
 import io.github.muntashirakon.AppManager.self.SelfPermissions;
 import io.github.muntashirakon.AppManager.utils.ContextUtils;
+import io.github.muntashirakon.AppManager.utils.ExUtils;
 import io.github.muntashirakon.AppManager.utils.FileUtils;
 import io.github.muntashirakon.io.fs.VirtualFileSystem;
 
@@ -188,7 +189,11 @@ class PathImpl extends Path {
             case ContentResolver.SCHEME_CONTENT:
                 if (isDocumentsProvider(context, uri.getAuthority())) { // We can't use DocumentsContract.isDocumentUri() because it expects something that isn't always correct
                     boolean isTreeUri = DocumentsContractCompat.isTreeUri(uri);
-                    documentFile = Objects.requireNonNull(isTreeUri ? DocumentFile.fromTreeUri(context, uri) : DocumentFile.fromSingleUri(context, uri));
+                    documentFile = ExUtils.requireNonNullOrThrow(
+                        isTreeUri ? DocumentFile.fromTreeUri(  context, uri)
+                                  : DocumentFile.fromSingleUri(context, uri),
+                        () -> new IOException("Invalid SAF URI: " + uri)
+                    );
                 } else {
                     // Content provider
                     documentFile = new MediaDocumentFile(null, context, uri);
@@ -211,7 +216,10 @@ class PathImpl extends Path {
                             String[] pathComponents = path.split(File.separator);
                             DocumentFile finalDocumentFile = rootPath.documentFile;
                             for (String pathComponent : pathComponents) {
-                                finalDocumentFile = Objects.requireNonNull(finalDocumentFile.findFile(pathComponent));
+                                    finalDocumentFile = ExUtils.requireNonNullOrThrow(
+                                            finalDocumentFile.findFile(pathComponent),
+                                            () -> new IOException("Invalid VFS path component: " + pathComponent)
+                                    );
                             }
                             documentFile = finalDocumentFile;
                         }


### PR DESCRIPTION
**Reviewer Summary**
On some file errors (e.g. invalid file name or invalid SAF/VFS path),
PathImpl now throws a checked IOException that is handled by the caller.
Previously these situations produced an unchecked NullPointerException,
which bypasses normal error handling and ultimately crashes the app.
This change fixes #1932 and aligns file‑related failures with the
expected checked‑exception model.


**description**
This PR fixes the crash described in issue #1932.

PathImpl previously relied on Objects.requireNonNull(...) in several
SAF and VFS resolution paths. When DocumentFile.fromTreeUri(),
fromSingleUri(), or findFile() returned null (e.g. invalid SAF URI,
missing permissions, or non-existing VFS path components), the code
threw an unchecked NullPointerException ( in short NPE ) , causing the app to crash.

These cases represent normal file-related failure conditions and should
be reported via a checked IOException rather than an unchecked NPE.

Changes included:
- Added ExUtils.requireNonNullOrThrow(...) to provide safe null
  validation with caller-defined IOException.
- Updated PathImpl to use this helper for SAF and VFS path resolution.
- Ensures invalid paths now produce a proper IOException instead of
  crashing the app.

This aligns PathImpl with the expected error-handling model, improves
robustness, and prevents crashes when users enter invalid paths.
