### PR TITLE
fix: Gradle 9.0 syntax compliance and Windows build compatibility

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace 'io.github.muntashirakon.AppManager'
+    namespace = 'io.github.muntashirakon.AppManager'
     compileSdk compile_sdk
     buildToolsVersion = build_tools
 
@@ -51,19 +51,19 @@ android {
         debug {
             applicationIdSuffix '.debug'
             versionNameSuffix '-DEBUG'
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
             resValue "string", "app_name", "AM Debug"
         }
     }
     lint {
-        checkReleaseBuilds false
-        abortOnError false
-        checkDependencies true
+        checkReleaseBuilds = false
+        abortOnError = false
+        checkDependencies = true
     }
     compileOptions {
-        encoding "UTF-8"
+        encoding = "UTF-8"
         // Flag to enable support for the new language APIs
-        coreLibraryDesugaringEnabled true
+        coreLibraryDesugaringEnabled = true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -76,7 +76,7 @@ android {
         abi {
             reset()
             include 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
-            universalApk true
+            universalApk = true
         }
     }
     aaptOptions {
@@ -91,12 +91,12 @@ android {
         androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
     dependenciesInfo {
-        includeInApk false
-        includeInBundle false
+        includeInApk = false
+        includeInBundle = false
     }
     packagingOptions {
         jniLibs {
-            useLegacyPackaging true
+            useLegacyPackaging = true
         }
         resources {
             excludes += ['META-INF/*.version']
@@ -104,8 +104,8 @@ android {
         }
     }
     buildFeatures {
-        aidl true
-        buildConfig true
+        aidl = true
+        buildConfig = true
     }
 }
 
@@ -203,7 +203,7 @@ android.applicationVariants.configureEach { variant ->
 }
 
 def buildTime() {
-    var commitTime = "git show --no-patch --format=%ct000".execute([], project.rootDir).text.trim()
+    var commitTime = ["git", "show", "--no-patch", "--format=%ct000"].execute([], project.rootDir).text.trim()
     if (isDigitsOnly(commitTime)) {
         return Long.parseLong(commitTime)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
+        maven { url = "https://jitpack.io" }
     }
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile).tap {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    namespace 'io.github.muntashirakon.AppManager.docs'
+    namespace = 'io.github.muntashirakon.AppManager.docs'
     compileSdk compile_sdk
     buildToolsVersion = build_tools
 
@@ -17,7 +17,7 @@ android {
     }
 
     compileOptions {
-        encoding "UTF-8"
+        encoding = "UTF-8"
     }
 }
 
@@ -26,15 +26,32 @@ interface InjectedExecOps {
     @Inject
     ExecOperations getExecOps()
 }
-
 tasks.register('buildDocs') {
     def injected = project.objects.newInstance(InjectedExecOps)
     doLast {
         println("=== docs: start ===")
         String buildExec = "${rootProject.projectDir.absolutePath}/scripts/make_docs.sh"
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
+
+        if (isWindows) {
+            // Change Windows CRLF to LF
+            File scriptFile = new File(buildExec)
+            if (scriptFile.exists()) {
+                scriptFile.text = scriptFile.text.replace("\r\n", "\n")
+            }
+        }
+
         injected.execOps.exec {
             workingDir = project.rootDir
-            executable = buildExec
+            if (isWindows) {
+                //On Windows, Bash is intercepted by WSL (Ubuntu by default);
+                //Use clean formatting and relative paths.
+                executable = "bash"
+                args = ["scripts/make_docs.sh"]
+            } else {
+                // macOS/Linux
+                executable = buildExec
+            }
         }
         println("=== docs: finish ===")
     }

--- a/hiddenapi/build.gradle
+++ b/hiddenapi/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    namespace 'io.github.muntashirakon.hiddenapi'
+    namespace = 'io.github.muntashirakon.hiddenapi'
     compileSdk compile_sdk
     buildToolsVersion = build_tools
 

--- a/libcore/compat/build.gradle
+++ b/libcore/compat/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    namespace 'io.github.muntashirakon.AppManager.compat'
+    namespace = 'io.github.muntashirakon.AppManager.compat'
     compileSdk compile_sdk
     buildToolsVersion = build_tools
 
@@ -15,7 +15,7 @@ android {
     }
 
     compileOptions {
-        encoding "UTF-8"
+        encoding = "UTF-8"
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -26,7 +26,7 @@ android {
         }
     }
     buildFeatures {
-        buildConfig true
+        buildConfig = true
     }
 }
 

--- a/libcore/io/build.gradle
+++ b/libcore/io/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    namespace 'io.github.muntashirakon.io'
+    namespace = 'io.github.muntashirakon.io'
     compileSdk compile_sdk
     buildToolsVersion = build_tools
 
@@ -15,13 +15,13 @@ android {
     }
 
     compileOptions {
-        encoding "UTF-8"
+        encoding = "UTF-8"
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     buildFeatures {
-        aidl true
-        buildConfig true
+        aidl = true
+        buildConfig = true
     }
 }
 

--- a/libcore/ui/build.gradle
+++ b/libcore/ui/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    namespace 'io.github.muntashirakon.ui'
+    namespace = 'io.github.muntashirakon.ui'
     compileSdk compile_sdk
     buildToolsVersion = build_tools
 
@@ -17,7 +17,7 @@ android {
     }
 
     compileOptions {
-        encoding "UTF-8"
+        encoding = "UTF-8"
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }

--- a/libopenpgp/build.gradle
+++ b/libopenpgp/build.gradle
@@ -3,7 +3,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'org.openintents.openpgp'
+    namespace = 'org.openintents.openpgp'
     compileSdk compile_sdk
     buildToolsVersion = build_tools
 
@@ -13,12 +13,12 @@ android {
     }
 
     compileOptions {
-        encoding "UTF-8"
+        encoding = "UTF-8"
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     buildFeatures {
-        aidl true
+        aidl = true
     }
 }
 

--- a/libserver/build.gradle
+++ b/libserver/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    namespace 'io.github.muntashirakon.AppManager.server.common'
+    namespace = 'io.github.muntashirakon.AppManager.server.common'
     compileSdk compile_sdk
     buildToolsVersion = build_tools
 
@@ -15,12 +15,12 @@ android {
     }
 
     compileOptions {
-        encoding "UTF-8"
+        encoding = "UTF-8"
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     buildFeatures {
-        aidl true
+        aidl = true
     }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 android {
-    namespace 'io.github.muntashirakon.AppManager.server'
+    namespace = 'io.github.muntashirakon.AppManager.server'
     compileSdk compile_sdk
     buildToolsVersion = build_tools
 
@@ -21,7 +21,7 @@ android {
     }
 
     compileOptions {
-        encoding "UTF-8"
+        encoding = "UTF-8"
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -68,7 +68,11 @@ android.libraryVariants.configureEach { variant ->
             String libserverClassDir = libServerCompileTask.get().destinationDirectory.get().asFile.absolutePath + "/${serverPkg}/common"
 
             String androidJar = "${android.sdkDirectory.path}/platforms/android-${target_sdk}/android.jar"
-            String d8Path = "${android.sdkDirectory.path}/build-tools/${android.buildToolsVersion}/d8"
+            // Get OS Name and Determine whether the os is Windows
+            boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows")
+            // Modify the File Name according to OS type
+            String d8Executable = isWindows ? "d8.bat" : "d8"
+            String d8Path = "${android.sdkDirectory.path}/build-tools/${android.buildToolsVersion}/${d8Executable}"
 
             println("Creating am.jar...")
             def amArgs = ['--release', '--min-api', min_sdk, '--output', amJar.absolutePath, '--lib', androidJar]

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0 AND GPL-3.0-or-later
 include ':app'
-include ':docs'
 include ':hiddenapi'
 include ':libcore:compat'
 include ':libcore:io'
@@ -8,5 +7,6 @@ include ':libcore:ui'
 include ':libopenpgp'
 include ':libserver'
 include ':server'
+include ':docs'
 rootProject.name = "AppManager"
 gradle.ext.appManagerRoot = settingsDir


### PR DESCRIPTION
1. Fix 14 deprecated Groovy space-assignment properties (34 occurrences across 10 gradle files) by replacing `propName value` with `propName = value`, as required for Gradle 10 compatibility.

2. Add Windows support for docs:buildDocs task:
(1) Inject bash as executable to work with WSL
(2) Auto-convert CRLF to LF line endings for shell scripts
(3) Use relative path instead of absolute path to avoid WSL failing to resolve "C:\\" (exit code 127)

3. Add Windows support for server:createServerJars task:
Select d8.bat or d8 based on OS type for correct executable path under build-tools

4. Fix Windows compatibility for buildTime() in app/build.gradle:
Change "git show ...".execute() to ["git", "show", ...].execute() to bypass shell tokenization issues on Windows